### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this package are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] - 2026-06-22
+
+### Security
+
+- Normalize the one-time-code regex with the `/u` flag for multibyte safety.
+
+### Documentation
+
+- Recommend layering a CAPTCHA on the request form for high-risk deployments.
+
+## [0.1.0] - 2026-06-22
+
+### Added
+
+- Passwordless email authentication via magic links and one-time codes.
+- Scanner-safe, prefetch-safe consumption: an inert signed `GET` confirmation page
+  and a `POST`-only, atomically claimed single-use token.
+- Optional, isolated Laravel Fortify bridge that routes a confirmed-two-factor user
+  through Fortify's challenge with no bypass, verified end-to-end against the real
+  Fortify TOTP flow.
+- Enumeration-resistant request endpoint, per-email and per-IP rate limiting, and a
+  per-token attempt lockout for code mode.
+- Boot-time, fail-closed entropy guardrail that refuses brute-forceable code
+  configurations, with the generator and guardrail sharing one canonical
+  distinct-character alphabet.
+- An `email-magic-link:purge` command to delete expired and consumed tokens.
+- Swappable authenticator, user-lookup, token-store, and notification, plus
+  observability events (`MagicLinkRequested`, `MagicLinkVerified`,
+  `TwoFactorChallengeRequired`).
+- Publishable configuration, migration, and views.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+Thanks for considering a contribution. This package holds itself to a strict quality
+bar, and every pull request is expected to keep all of the gates green.
+
+## Getting started
+
+```bash
+git clone git@github.com:pushery/email-magic-link-for-laravel.git
+cd email-magic-link-for-laravel
+composer install
+```
+
+## Quality gates
+
+All of the following must pass. The aggregate static + test gate is:
+
+```bash
+composer qa
+```
+
+which runs, and each can be run on its own:
+
+| Command | Gate |
+|---|---|
+| `composer format:test` | Code style — Laravel Pint, zero diffs (`composer format` to fix). |
+| `composer rector:test` | Refactoring — Rector with the PHP 8.4 rule set, dry-run clean (`composer rector` to apply). |
+| `composer analyse` | Static analysis — Larastan at `max` level, no errors. |
+| `composer test:type-coverage` | 100% type coverage of `src/`. |
+| `composer test:coverage` | 100% line coverage of `src/`. |
+| `composer mutate` | Mutation testing (see below). |
+
+### Tests
+
+The suite uses [Pest](https://pestphp.com) and Orchestra Testbench. The defining axis is
+**Fortify present versus absent**: the `Integration` suite boots Fortify, while the
+`Unit` and `Feature` suites run the core in isolation and must never reference a Fortify
+symbol. CI exercises both axes across PHP 8.4/8.5, the lowest and highest dependency
+resolutions, and with and without Fortify.
+
+The `Postgres` suite verifies the `RETURNING`-based atomic claim against a real
+PostgreSQL connection. It is skipped automatically when Postgres is unavailable; to run
+it locally, provide a database and set `PG_TEST_HOST`, `PG_TEST_PORT`, `PG_TEST_DB`,
+`PG_TEST_USER`, and `PG_TEST_PASSWORD` as needed (defaults target
+`127.0.0.1:5432` / `email_magic_link_test` / `postgres`).
+
+### Mutation testing
+
+Mutation testing runs through Pest 4's built-in mutation plugin (Infection does not
+support Pest 4's function-style tests). The gate is an overall mutation score indicator
+of at least 85%; the security-critical paths — the atomic claim, the entropy guardrail,
+and the two-factor handoff — are mutation-tested to effectively 100%, and the residual
+gap is made up of equivalent mutants in glue and presentation code (for example the
+PostgreSQL/portable claim branches, which are behaviorally identical because SQLite
+also supports `RETURNING`). Please do not add assertions whose only purpose is to kill an
+equivalent mutant.
+
+## Pull request expectations
+
+- Keep `composer qa` and `composer mutate` green.
+- Add tests for behavior changes; the security invariants in `SECURITY.md` must stay
+  covered.
+- Update `README.md` and `CHANGELOG.md` (`## [Unreleased]`) when behavior or
+  configuration changes.
+- Keep commits focused and the public API stable, or call out the break explicitly.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pushery
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,161 @@ If a user has confirmed TOTP through Fortify, clicking a magic link does **not**
 ### 2. Scanner-safe and prefetch-safe link consumption
 
 The emailed link is a `GET` that **only renders a confirmation page** — it performs no authentication and no state change. The single-use token is consumed solely by an explicit `POST` from that page. Corporate email security scanners (Microsoft SafeLinks, Mimecast, Proofpoint) and browser prefetch follow the `GET` and cannot burn the link before the human clicks "Sign in".
+
+---
+
+## Requirements
+
+| Component | Constraint |
+|---|---|
+| PHP | `^8.4` (8.4 and 8.5) |
+| Laravel | `^13.0` |
+| Laravel Fortify | `^1.0` — optional, only for the two-factor handoff |
+
+The package requires `laravel/framework` (for the `FormRequest` base it validates with) and adds no third-party runtime dependencies. Fortify is a **suggested** dependency; the core never references a Fortify symbol unless Fortify is installed and the bridge is enabled.
+
+## Installation
+
+```bash
+composer require pushery/email-magic-link-for-laravel
+```
+
+Publish and run the migration:
+
+```bash
+php artisan vendor:publish --tag=email-magic-link-migrations
+php artisan migrate
+```
+
+The migration is also auto-loaded, so a fresh app works without publishing. Optionally publish the config and views:
+
+```bash
+php artisan vendor:publish --tag=email-magic-link-config
+php artisan vendor:publish --tag=email-magic-link-views
+```
+
+## Quick start
+
+Out of the box the package registers a complete browser flow under the `web` middleware group:
+
+| Method | URI | Name | Purpose |
+|---|---|---|---|
+| `GET` | `/magic-link` | `email-magic-link.request.form` | "Enter your email" form |
+| `POST` | `/magic-link` | `email-magic-link.request` | Issue a link or code |
+| `GET` | `/magic-link/verify/{token}` | `email-magic-link.confirm` | Inert, signed confirmation page |
+| `POST` | `/magic-link/verify/{token}` | `email-magic-link.consume` | Consume a magic link |
+| `GET` | `/magic-link/code` | `email-magic-link.code.form` | Enter a one-time code |
+| `POST` | `/magic-link/code` | `email-magic-link.code.consume` | Consume a one-time code |
+
+Point your "log in" link at `route('email-magic-link.request.form')` and you have passwordless login. A user enters their email, receives a link, clicks it, confirms, and is signed in.
+
+## The three configurations
+
+**Standalone — no Fortify.** A verified user is logged in directly with `Auth::login`. There is no second factor in standalone mode, by design.
+
+**With Fortify, bridge on (`fortify.mode = 'auto'`, the default).** A user with confirmed TOTP is routed through Fortify's challenge; everyone else logs in directly.
+
+**With Fortify, bridge off (`fortify.mode = false`).** Fortify can be installed for other flows while the magic-link channel ignores it entirely and logs users in directly.
+
+The channel itself can be turned off completely with `enabled = false`, independent of whether Fortify is installed.
+
+## Why a magic link costs one extra click
+
+Because consumption is `POST`-only, the user clicks the emailed link (a `GET`) and then clicks "Sign in" on the confirmation page. That second click is the price of being safe against link-following security scanners and prefetch — tools that would otherwise spend a single-use token before the person ever sees it. We consider that trade-off worth it; it is the whole point of the package.
+
+For first-party SPA or mobile clients that exchange the token over JSON without an interstitial, set `api.enabled = true` and `POST` the token with an `Accept: application/json` header.
+
+## The two-factor handoff (and its trade-off)
+
+When the bridge is active and a verified user has **confirmed** two-factor authentication (gated on `two_factor_confirmed_at`, not merely a stored secret, so a user mid-setup is never locked out):
+
+1. The token is consumed.
+2. Fortify's `login.id` session key is set and the request is redirected to Fortify's `two-factor.login` challenge — **without** logging the user in.
+3. The login completes inside Fortify only after the TOTP code passes.
+
+**Trade-off:** the token is already spent when the handoff happens, so if a user abandons the TOTP step they must request a fresh link. This is intentional — the link is single-use and the challenge is a separate, deliberate step.
+
+**Guard alignment:** when the handoff is enabled, `email-magic-link.guard` must resolve to the same provider as `fortify.guard`, because Fortify re-resolves the challenged user from its own guard's provider. With mismatched providers the challenge fails closed (the user cannot complete login) rather than logging anyone in. The default `web` guard satisfies this out of the box.
+
+`fortify.respect_two_factor = false` disables this handoff. **This is a security downgrade: magic-link logins will skip two-factor for users who have it enabled.** It emits a warning at boot.
+
+## Configuration
+
+All values live in `config/email-magic-link.php`.
+
+| Key | Default | Purpose |
+|---|---|---|
+| `enabled` | `true` | Master switch for the channel (routes, notifications, limiters). |
+| `mode` | `'link'` | `'link'`, `'code'`, or `'both'`. |
+| `ttl` | `900` | Token lifetime in seconds. |
+| `code_length` | `8` | One-time code length. |
+| `code_alphabet` | unambiguous A–Z/2–9 | Alphabet for codes (governs keyspace). |
+| `max_attempts_per_token` | `5` | Hard per-token lockout for code mode. |
+| `entropy_safety_factor` | `1_000_000` | Guardrail bar; cannot be lowered below this floor. |
+| `guard` | app default | Stateful guard to log into. |
+| `user_lookup` | bundled | `UserLookup` implementation. |
+| `token_store` | bundled | `TokenStore` implementation. |
+| `notification` | `MagicLinkNotification` | Notification class (extend it to customize). |
+| `routes.prefix` | `''` | Route prefix. |
+| `routes.middleware` | `['web']` | Route middleware (sessions + CSRF). |
+| `routes.redirect_to` | `'/'` | Fallback redirect after login. |
+| `api.enabled` | `false` | Direct JSON token exchange for SPA/mobile. |
+| `fortify.mode` | `'auto'` | `'auto'` (on if Fortify present), `true`, or `false`. |
+| `fortify.respect_two_factor` | `true` | Route confirmed-2FA users through the challenge. |
+| `fortify.challenge_route` | `'two-factor.login'` | Fortify challenge route name. |
+| `limiters.request` / `limiters.consume` | named limiters | Override with `RateLimiter::for()`. |
+| `limits.request` / `limits.consume` | `5` / `10` per minute | Defaults for the bundled limiters. |
+
+## One-time codes
+
+Set `mode` to `'code'` (or `'both'`) to email a short code instead of a link. Codes are governed by a **boot-time entropy guardrail**: the package refuses to boot if a code's keyspace divided by its attempt lockout falls below `entropy_safety_factor`, naming the exact keys to fix and the minimum length that would pass. Magic links carry 256 bits of entropy and pass trivially.
+
+In `'both'` mode the request endpoint issues a link by default, or a code when `channel=code` is submitted.
+
+## Cleaning up tokens
+
+Every request inserts a row, and consumption only marks it consumed. Schedule the bundled command to delete expired and consumed tokens so the table stays small:
+
+```php
+use Illuminate\Support\Facades\Schedule;
+
+Schedule::command('email-magic-link:purge')->daily();
+```
+
+## Extension points
+
+**Take over the post-verification flow** by rebinding the authenticator contract:
+
+```php
+use EmailMagicLink\Contracts\MagicLinkAuthenticator;
+
+$this->app->bind(MagicLinkAuthenticator::class, MyAuthenticator::class);
+```
+
+The contract returns a response, so it — not an event — is where login-versus-2FA is decided.
+
+**React to events** (observability only — they must not drive flow control):
+
+- `MagicLinkRequested($user, $channel, $request)`
+- `MagicLinkVerified($user, $request)`
+- `TwoFactorChallengeRequired($user, $request)` (fired by the bridge)
+
+Successful logins also fire Laravel's own `Illuminate\Auth\Events\Login`.
+
+**Swap collaborators** via config: the `notification` class (extend `MagicLinkNotification`), a `UserLookup` (resolve users your way), and a `TokenStore` (custom persistence).
+
+## Security at rest
+
+Tokens are never stored in the clear — only a keyed HMAC-SHA256 hash, looked up via an index. Consumption is a single race-free conditional claim (PostgreSQL `RETURNING`, with a portable affected-rows fallback) so two concurrent requests can never both succeed. Links are additionally protected by Laravel signed routes. Raw tokens and full link URLs are never logged.
+
+The request endpoint is rate-limited per email and per IP out of the box. For high-risk deployments, layer a CAPTCHA or challenge widget on the request form as an additional bot-protection measure — that is a host-application concern this package deliberately leaves to you.
+
+See [SECURITY.md](SECURITY.md) for the supported versions and how to report a vulnerability.
+
+## Versioning
+
+This package follows [Semantic Versioning](https://semver.org). It is in its `0.x` line while the public API settles; the backward-compatibility promise begins at `1.0.0`.
+
+## License
+
+The MIT License. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported versions
+
+While this package is in its `0.x` line, security fixes are released against the latest minor version only.
+
+| Version | Supported |
+|---|---|
+| `0.x` (latest) | :white_check_mark: |
+| older | :x: |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Report them privately through GitHub's [private vulnerability reporting](https://github.com/pushery/email-magic-link-for-laravel/security/advisories/new) (the "Report a vulnerability" button on the repository's Security tab). Include:
+
+- a description of the vulnerability and its impact,
+- the steps to reproduce it,
+- the affected version(s),
+- and, if possible, a suggested fix.
+
+You can expect an acknowledgment within **3 business days** and an assessment of the report, including a remediation timeline, within **10 business days**. We will keep you informed throughout and credit you in the release notes once a fix ships, unless you prefer to remain anonymous.
+
+## Scope
+
+This package's security model rests on a few invariants, all covered by the test suite:
+
+- The emailed `GET` link is inert; the single-use token is consumed only on an explicit `POST`.
+- Token consumption is atomic — two concurrent requests can never both succeed.
+- A magic-link user with confirmed two-factor authentication is routed through Fortify's challenge and is never logged in without the second factor.
+- The request endpoint is enumeration-resistant.
+- Code mode is protected by a boot-time entropy guardrail.
+
+Reports that demonstrate a break in any of these invariants are especially valuable.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,82 @@
+{
+    "name": "pushery/email-magic-link-for-laravel",
+    "description": "Passwordless email magic-link & OTP authentication for Laravel — standalone or with a correct, no-bypass Fortify 2FA handoff and scanner-safe link consumption.",
+    "keywords": [
+        "laravel",
+        "authentication",
+        "magic-link",
+        "passwordless",
+        "otp",
+        "fortify",
+        "2fa",
+        "login"
+    ],
+    "license": "MIT",
+    "type": "library",
+    "homepage": "https://github.com/pushery/email-magic-link-for-laravel",
+    "support": {
+        "issues": "https://github.com/pushery/email-magic-link-for-laravel/issues",
+        "source": "https://github.com/pushery/email-magic-link-for-laravel"
+    },
+    "require": {
+        "php": "^8.4",
+        "ext-json": "*",
+        "laravel/framework": "^13.0"
+    },
+    "require-dev": {
+        "larastan/larastan": "^3.0",
+        "laravel/fortify": "^1.0",
+        "laravel/pint": "^1.0",
+        "orchestra/testbench": "^11.0",
+        "pestphp/pest": "^4.0",
+        "pestphp/pest-plugin-laravel": "^4.0",
+        "pestphp/pest-plugin-type-coverage": "^4.0",
+        "rector/rector": "^2.0"
+    },
+    "suggest": {
+        "laravel/fortify": "Enables the no-bypass two-factor (TOTP) handoff: a magic-link user with confirmed 2FA completes Fortify's challenge before being logged in (^1.0)."
+    },
+    "autoload": {
+        "psr-4": {
+            "EmailMagicLink\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "EmailMagicLink\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "pest",
+        "test:coverage": "pest --coverage --min=100",
+        "test:type-coverage": "pest --type-coverage --min=100",
+        "analyse": "phpstan analyse",
+        "format": "pint",
+        "format:test": "pint --test",
+        "rector": "rector process",
+        "rector:test": "rector process --dry-run",
+        "mutate": "pest --mutate --everything --covered-only --parallel --min=85",
+        "qa": [
+            "@format:test",
+            "@rector:test",
+            "@analyse",
+            "@test:type-coverage",
+            "@test:coverage"
+        ]
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "EmailMagicLink\\EmailMagicLinkServiceProvider"
+            ]
+        }
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
+}

--- a/config/email-magic-link.php
+++ b/config/email-magic-link.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+use EmailMagicLink\Notifications\MagicLinkNotification;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Master switch
+    |--------------------------------------------------------------------------
+    |
+    | Turns the magic-link channel on or off independently of whether Fortify
+    | is installed. When false, no routes, notifications, or rate limiters are
+    | registered: the package becomes inert.
+    |
+    */
+
+    'enabled' => env('EMAIL_MAGIC_LINK_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication mode
+    |--------------------------------------------------------------------------
+    |
+    | "link" emails a high-entropy magic link, "code" emails a short numeric or
+    | alphanumeric one-time code, and "both" offers either. Code mode is bound
+    | by the entropy guardrail (see below); link mode passes it trivially.
+    |
+    | Supported: "link", "code", "both"
+    |
+    */
+
+    'mode' => env('EMAIL_MAGIC_LINK_MODE', 'link'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Token lifetime (seconds)
+    |--------------------------------------------------------------------------
+    |
+    | How long an issued link or code stays valid. Expired tokens are rejected
+    | regardless of whether they were ever consumed.
+    |
+    */
+
+    'ttl' => (int) env('EMAIL_MAGIC_LINK_TTL', 900),
+
+    /*
+    |--------------------------------------------------------------------------
+    | One-time code (code mode)
+    |--------------------------------------------------------------------------
+    |
+    | The keyspace of a code is (distinct characters) ^ length. Codes are drawn
+    | uniformly from the distinct characters of the alphabet, so repeated
+    | characters do not add entropy. Together with the per-token attempt lockout
+    | this determines brute-force resistance, which the boot-time entropy
+    | guardrail enforces. The default alphabet omits visually ambiguous
+    | characters (0/O, 1/I/L) for readability.
+    |
+    */
+
+    'code_length' => 8,
+
+    'code_alphabet' => 'ABCDEFGHJKMNPQRSTUVWXYZ23456789',
+
+    'max_attempts_per_token' => 5,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Entropy safety factor
+    |--------------------------------------------------------------------------
+    |
+    | The guardrail requires keyspace / max_attempts_per_token >= this value,
+    | i.e. at most a 1-in-N chance of guessing a code within the lockout. It
+    | cannot be lowered to disable the check; obviously broken combinations
+    | (zero ttl, missing attempt cap) always fail closed.
+    |
+    */
+
+    'entropy_safety_factor' => 1_000_000,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Guard and user resolution
+    |--------------------------------------------------------------------------
+    |
+    | The stateful guard to log the user into, and how to resolve a user from a
+    | submitted email. Leave "guard" null to use the application default; by
+    | default users are resolved through that guard's configured provider.
+    | Provide a "user_lookup" class implementing the UserLookup contract to fully
+    | control resolution (custom columns, multi-tenancy, soft-deletes, and so on).
+    |
+    | When the Fortify two-factor handoff is enabled, "guard" must resolve to the
+    | same provider as "fortify.guard" so Fortify can re-resolve the challenged
+    | user from the same table.
+    |
+    */
+
+    'guard' => env('EMAIL_MAGIC_LINK_GUARD'),
+
+    'user_lookup' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Token store
+    |--------------------------------------------------------------------------
+    |
+    | The implementation of the TokenStore contract responsible for issuing,
+    | hashing, and atomically claiming tokens. Leave null for the bundled
+    | Eloquent-backed store.
+    |
+    */
+
+    'token_store' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Notification
+    |--------------------------------------------------------------------------
+    |
+    | The notification used to deliver the link or code. Swap it for your own
+    | to control branding, channels, and copy.
+    |
+    */
+
+    'notification' => MagicLinkNotification::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Routing
+    |--------------------------------------------------------------------------
+    |
+    | The browser flow needs the "web" middleware group for sessions and CSRF.
+    | "redirect_to" is the fallback destination after a successful login when no
+    | intended URL was captured.
+    |
+    */
+
+    'routes' => [
+        'prefix' => '',
+        'middleware' => ['web'],
+        'redirect_to' => '/',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | API token exchange
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, first-party SPA and mobile clients may exchange a token via
+    | a direct JSON POST without the browser interstitial. The secure default
+    | for the browser flow remains the GET confirmation page.
+    |
+    */
+
+    'api' => [
+        'enabled' => false,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Fortify bridge
+    |--------------------------------------------------------------------------
+    |
+    | "mode" controls activation of the optional two-factor handoff:
+    |   "auto"  activate only when laravel/fortify is installed
+    |   true    same, and warn at boot if Fortify is missing
+    |   false   never activate, even when Fortify is installed
+    |
+    | "respect_two_factor" governs whether a magic-link user with confirmed TOTP
+    | is routed through Fortify's challenge. Setting it false is a deliberate
+    | security downgrade that disables 2FA for magic-link logins; it emits a
+    | boot-time warning.
+    |
+    */
+
+    'fortify' => [
+        'mode' => env('EMAIL_MAGIC_LINK_FORTIFY', 'auto'),
+        'respect_two_factor' => true,
+        'challenge_route' => 'two-factor.login',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Rate limiting
+    |--------------------------------------------------------------------------
+    |
+    | Named limiters applied to the request and consume endpoints. Override them
+    | from your application with RateLimiter::for() using the same names. The
+    | "limits" defaults below are used by the bundled limiter definitions.
+    |
+    */
+
+    'limiters' => [
+        'request' => 'email-magic-link:request',
+        'consume' => 'email-magic-link:consume',
+    ],
+
+    'limits' => [
+        'request' => ['max' => 5, 'per_minutes' => 1],
+        'consume' => ['max' => 10, 'per_minutes' => 1],
+    ],
+
+];

--- a/database/migrations/0001_01_01_000000_create_magic_link_tokens_table.php
+++ b/database/migrations/0001_01_01_000000_create_magic_link_tokens_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('magic_link_tokens', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+
+            // String so the table works with integer, UUID, or ULID user keys.
+            $table->string('user_id')->index();
+            $table->string('guard');
+
+            // Keyed hash of the secret; the raw token or code is never stored.
+            $table->string('token_hash', 64)->index();
+
+            $table->string('channel', 8);
+            $table->unsignedInteger('attempts')->default(0);
+
+            $table->timestamp('expires_at')->index();
+            $table->timestamp('consumed_at')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('magic_link_tokens');
+    }
+};

--- a/resources/views/code.blade.php
+++ b/resources/views/code.blade.php
@@ -1,0 +1,32 @@
+@extends('email-magic-link::layout')
+
+@section('title', 'Enter your code')
+
+@section('content')
+    <h1>Enter your sign-in code</h1>
+    <p>We emailed you a one-time code. Enter it below to finish signing in.</p>
+
+    @if (session('status'))
+        <div class="status" role="status">{{ session('status') }}</div>
+    @endif
+
+    <form method="POST" action="{{ route('email-magic-link.code.consume') }}">
+        @csrf
+
+        <label for="email">Email address</label>
+        <input id="email" name="email" type="email" autocomplete="email" required value="{{ $email ?: old('email') }}">
+
+        <label for="code" style="margin-top:1rem">Sign-in code</label>
+        <input id="code" name="code" type="text" inputmode="text" autocomplete="one-time-code" required autofocus>
+
+        @error('code')
+            <p class="error">{{ $message }}</p>
+        @enderror
+
+        @error('email')
+            <p class="error">{{ $message }}</p>
+        @enderror
+
+        <button type="submit">Sign in</button>
+    </form>
+@endsection

--- a/resources/views/confirm.blade.php
+++ b/resources/views/confirm.blade.php
@@ -1,0 +1,17 @@
+@extends('email-magic-link::layout')
+
+@section('title', 'Confirm sign in')
+
+@section('content')
+    <h1>Sign in to {{ config('app.name') }}</h1>
+    <p>For your security, confirm that you want to sign in. This link can only be used once.</p>
+
+    @error('email')
+        <p class="error">{{ $message }}</p>
+    @enderror
+
+    <form method="POST" action="{{ $action }}">
+        @csrf
+        <button type="submit">Sign in</button>
+    </form>
+@endsection

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <title>@yield('title', 'Sign in') &middot; {{ config('app.name') }}</title>
+    <style>
+        :root { color-scheme: light dark; }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+            background: Canvas;
+            color: CanvasText;
+        }
+        main {
+            width: 100%;
+            max-width: 24rem;
+            padding: 2rem;
+            box-sizing: border-box;
+        }
+        h1 { font-size: 1.25rem; margin: 0 0 1rem; }
+        p { line-height: 1.5; margin: 0 0 1rem; }
+        label { display: block; font-weight: 600; margin: 0 0 0.25rem; }
+        input[type="email"], input[type="text"] {
+            width: 100%;
+            padding: 0.6rem 0.75rem;
+            font-size: 1rem;
+            box-sizing: border-box;
+            border: 1px solid GrayText;
+            border-radius: 0.5rem;
+            background: Field;
+            color: FieldText;
+        }
+        button {
+            width: 100%;
+            margin-top: 1rem;
+            padding: 0.65rem 1rem;
+            font-size: 1rem;
+            font-weight: 600;
+            border: 0;
+            border-radius: 0.5rem;
+            background: AccentColor;
+            color: AccentColorText;
+            cursor: pointer;
+        }
+        .status { padding: 0.75rem 1rem; border-radius: 0.5rem; background: color-mix(in srgb, AccentColor 15%, transparent); margin-bottom: 1rem; }
+        .error { color: #b00020; margin: 0.4rem 0 0; font-size: 0.9rem; }
+        fieldset { border: 0; padding: 0; margin: 0 0 1rem; }
+    </style>
+</head>
+<body>
+    <main>
+        @yield('content')
+    </main>
+</body>
+</html>

--- a/resources/views/request.blade.php
+++ b/resources/views/request.blade.php
@@ -1,0 +1,33 @@
+@extends('email-magic-link::layout')
+
+@section('title', 'Sign in')
+
+@section('content')
+    <h1>Sign in to {{ config('app.name') }}</h1>
+    <p>Enter your email address and we will send you a secure sign-in {{ $mode === 'code' ? 'code' : 'link' }}.</p>
+
+    @if (session('status'))
+        <div class="status" role="status">{{ session('status') }}</div>
+    @endif
+
+    <form method="POST" action="{{ route('email-magic-link.request') }}">
+        @csrf
+
+        <label for="email">Email address</label>
+        <input id="email" name="email" type="email" autocomplete="email" required autofocus value="{{ old('email') }}">
+
+        @error('email')
+            <p class="error">{{ $message }}</p>
+        @enderror
+
+        @if ($mode === 'both')
+            <fieldset>
+                <legend>Delivery</legend>
+                <label><input type="radio" name="channel" value="link" checked> Magic link</label>
+                <label><input type="radio" name="channel" value="code"> One-time code</label>
+            </fieldset>
+        @endif
+
+        <button type="submit">Send sign-in {{ $mode === 'code' ? 'code' : 'link' }}</button>
+    </form>
+@endsection

--- a/routes/email-magic-link.php
+++ b/routes/email-magic-link.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use EmailMagicLink\Http\Controllers\ConfirmMagicLinkController;
+use EmailMagicLink\Http\Controllers\ConsumeCodeController;
+use EmailMagicLink\Http\Controllers\ConsumeMagicLinkController;
+use EmailMagicLink\Http\Controllers\SendMagicLinkController;
+use EmailMagicLink\Http\Controllers\ShowCodeFormController;
+use EmailMagicLink\Http\Controllers\ShowRequestFormController;
+use Illuminate\Support\Facades\Route;
+
+$requestLimiter = (string) config('email-magic-link.limiters.request', 'email-magic-link:request');
+$consumeLimiter = (string) config('email-magic-link.limiters.consume', 'email-magic-link:consume');
+
+// All routes are registered whenever the channel is enabled; the configured
+// mode governs which one actually issues a token, not which routes exist.
+Route::get('magic-link', ShowRequestFormController::class)
+    ->name('email-magic-link.request.form');
+
+Route::post('magic-link', SendMagicLinkController::class)
+    ->middleware("throttle:{$requestLimiter}")
+    ->name('email-magic-link.request');
+
+// GET is signed and inert; only the POST consumes the token.
+Route::get('magic-link/verify/{token}', ConfirmMagicLinkController::class)
+    ->middleware('signed')
+    ->name('email-magic-link.confirm');
+
+Route::post('magic-link/verify/{token}', ConsumeMagicLinkController::class)
+    ->middleware("throttle:{$consumeLimiter}")
+    ->name('email-magic-link.consume');
+
+Route::get('magic-link/code', ShowCodeFormController::class)
+    ->name('email-magic-link.code.form');
+
+Route::post('magic-link/code', ConsumeCodeController::class)
+    ->middleware("throttle:{$consumeLimiter}")
+    ->name('email-magic-link.code.consume');

--- a/src/Authenticators/DefaultAuthenticator.php
+++ b/src/Authenticators/DefaultAuthenticator.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Authenticators;
+
+use EmailMagicLink\Contracts\MagicLinkAuthenticator;
+use EmailMagicLink\Support\MagicLinkConfig;
+use Illuminate\Auth\AuthManager;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Redirector;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Standalone post-verification flow: log the user into the stateful guard and
+ * redirect (or return JSON for API clients).
+ *
+ * There is no second factor here by design. When Fortify is installed and a
+ * user has confirmed TOTP, the bridge wraps this authenticator and intercepts
+ * first.
+ */
+final readonly class DefaultAuthenticator implements MagicLinkAuthenticator
+{
+    public function __construct(
+        private AuthManager $auth,
+        private Redirector $redirector,
+        private MagicLinkConfig $config,
+    ) {}
+
+    public function authenticate(Request $request, Authenticatable $user, bool $remember): Response
+    {
+        $guard = $this->auth->guard($this->config->guard());
+
+        if (! $guard instanceof StatefulGuard) {
+            throw new RuntimeException(
+                "The [{$this->config->guard()}] guard is not stateful and cannot be used for magic-link login.",
+            );
+        }
+
+        $guard->login($user, $remember);
+
+        if ($request->hasSession()) {
+            $request->session()->regenerate();
+        }
+
+        if ($request->expectsJson() && $this->config->apiEnabled()) {
+            return new JsonResponse([
+                'authenticated' => true,
+                'two_factor' => false,
+                'redirect' => $this->config->redirectTo(),
+            ]);
+        }
+
+        return $this->redirector->intended($this->config->redirectTo());
+    }
+}

--- a/src/Authenticators/FortifyAwareAuthenticator.php
+++ b/src/Authenticators/FortifyAwareAuthenticator.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Authenticators;
+
+use EmailMagicLink\Contracts\MagicLinkAuthenticator;
+use EmailMagicLink\Events\TwoFactorChallengeRequired;
+use EmailMagicLink\Support\MagicLinkConfig;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * The package's only Fortify-internal coupling.
+ *
+ * When the verified user has confirmed TOTP, the user is handed off to
+ * Fortify's own challenge in a NOT-yet-authenticated state: the login.id /
+ * login.remember session keys are set and the request is redirected to the
+ * challenge route. The actual login happens inside Fortify, only after the code
+ * passes. Calling the guard's login() before the redirect would defeat the
+ * guest middleware on the challenge route and bypass the second factor, so this
+ * decorator must never do so.
+ *
+ * Users without confirmed two-factor fall through to the wrapped default
+ * authenticator and are logged in directly.
+ */
+final readonly class FortifyAwareAuthenticator implements MagicLinkAuthenticator
+{
+    public function __construct(
+        private MagicLinkAuthenticator $default,
+        private MagicLinkConfig $config,
+    ) {}
+
+    public function authenticate(Request $request, Authenticatable $user, bool $remember): Response
+    {
+        if (! $this->config->respectTwoFactor() || ! $this->hasConfirmedTwoFactor($user)) {
+            return $this->default->authenticate($request, $user, $remember);
+        }
+
+        // Hand off as a guest. Do not log in here: Fortify completes the login
+        // after the TOTP code is verified.
+        $request->session()->put([
+            'login.id' => $user->getAuthIdentifier(),
+            'login.remember' => $remember,
+        ]);
+
+        event(new TwoFactorChallengeRequired($user, $request));
+
+        return redirect()->route($this->config->challengeRoute());
+    }
+
+    private function hasConfirmedTwoFactor(Authenticatable $user): bool
+    {
+        // Gate on confirmation, not mere secret presence, so a user mid-setup
+        // is not locked out of their own magic-link login.
+        return data_get($user, 'two_factor_confirmed_at') !== null;
+    }
+}

--- a/src/Console/Commands/PurgeExpiredTokensCommand.php
+++ b/src/Console/Commands/PurgeExpiredTokensCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Console\Commands;
+
+use EmailMagicLink\Contracts\TokenStore;
+use Illuminate\Console\Command;
+
+/**
+ * Deletes expired and consumed magic-link tokens.
+ *
+ * Schedule it (for example daily) so the token table does not grow unbounded:
+ * Schedule::command('email-magic-link:purge')->daily();
+ */
+final class PurgeExpiredTokensCommand extends Command
+{
+    protected $signature = 'email-magic-link:purge';
+
+    protected $description = 'Delete expired and consumed magic-link tokens.';
+
+    public function handle(TokenStore $store): int
+    {
+        $removed = $store->purge();
+
+        $this->info("Purged {$removed} magic-link token(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Contracts/MagicLinkAuthenticator.php
+++ b/src/Contracts/MagicLinkAuthenticator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Contracts;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Decides what happens once a token has been verified and atomically consumed.
+ *
+ * This is the package's single flow-control seam. The default binding logs the
+ * user in; the Fortify bridge rebinds it to hand a two-factor user off to the
+ * TOTP challenge. Rebind it in the container to take over post-verification
+ * flow entirely.
+ */
+interface MagicLinkAuthenticator
+{
+    /**
+     * Called after a token has been successfully verified and consumed.
+     *
+     * Implementations either log the user in and return a redirect/JSON
+     * response, or hand off to a second factor. They must return a response;
+     * they must not rely on events to redirect.
+     */
+    public function authenticate(Request $request, Authenticatable $user, bool $remember): Response;
+}

--- a/src/Contracts/TokenStore.php
+++ b/src/Contracts/TokenStore.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Contracts;
+
+use EmailMagicLink\Support\ClaimResult;
+use EmailMagicLink\Support\IssuedToken;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Issues, stores, and atomically consumes magic-link tokens and one-time codes.
+ *
+ * The raw secret is never persisted: only a keyed hash is stored and indexed.
+ * Consumption is a single race-free conditional claim, so two concurrent
+ * requests for the same token can never both succeed.
+ */
+interface TokenStore
+{
+    /**
+     * Issue a fresh token for the user and return the plaintext secret.
+     *
+     * @param  'link'|'code'  $channel
+     */
+    public function issue(Authenticatable $user, string $guard, string $channel): IssuedToken;
+
+    /**
+     * Atomically claim a magic-link token by its plaintext value.
+     */
+    public function claimLink(string $token): ClaimResult;
+
+    /**
+     * Atomically claim a one-time code for a known user, accounting for failed
+     * attempts and enforcing the per-token lockout.
+     */
+    public function claimCode(Authenticatable $user, string $code): ClaimResult;
+
+    /**
+     * Delete expired and consumed tokens. Returns the number removed.
+     */
+    public function purge(): int;
+}

--- a/src/Contracts/UserLookup.php
+++ b/src/Contracts/UserLookup.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Contracts;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Resolves the authenticatable a magic link should be issued for.
+ *
+ * Implementations must perform a constant-shape lookup: returning null for an
+ * unknown email is expected and must not differ observably (in timing or
+ * exceptions) from a hit, so the request endpoint stays enumeration-resistant.
+ */
+interface UserLookup
+{
+    public function findByEmail(string $email, string $guard): ?Authenticatable;
+}

--- a/src/EmailMagicLinkServiceProvider.php
+++ b/src/EmailMagicLinkServiceProvider.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink;
+
+use EmailMagicLink\Authenticators\DefaultAuthenticator;
+use EmailMagicLink\Console\Commands\PurgeExpiredTokensCommand;
+use EmailMagicLink\Contracts\MagicLinkAuthenticator;
+use EmailMagicLink\Contracts\TokenStore;
+use EmailMagicLink\Contracts\UserLookup;
+use EmailMagicLink\Lookups\DefaultUserLookup;
+use EmailMagicLink\Stores\DefaultTokenStore;
+use EmailMagicLink\Support\EntropyGuard;
+use EmailMagicLink\Support\MagicLinkConfig;
+use EmailMagicLink\Support\RateLimits;
+use EmailMagicLink\Support\TokenHasher;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
+use InvalidArgumentException;
+use Override;
+
+final class EmailMagicLinkServiceProvider extends ServiceProvider
+{
+    /**
+     * Probed via class_exists so the core never imports a Fortify symbol.
+     * Overridable in tests to simulate Fortify being absent.
+     */
+    public static string $fortifyClass = 'Laravel\\Fortify\\Fortify';
+
+    /**
+     * Whether the bundled migration is registered automatically. Disable it
+     * with self::ignoreMigrations() when publishing and managing it yourself.
+     */
+    public static bool $runsMigrations = true;
+
+    public static function ignoreMigrations(): void
+    {
+        self::$runsMigrations = false;
+    }
+
+    #[Override]
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/../config/email-magic-link.php', 'email-magic-link');
+
+        $this->app->singleton(
+            MagicLinkConfig::class,
+            fn (Application $app): MagicLinkConfig => new MagicLinkConfig($app->make(Repository::class)),
+        );
+
+        $this->app->singleton(TokenHasher::class, function (Application $app): TokenHasher {
+            $key = $app->make(Repository::class)->get('app.key');
+
+            return new TokenHasher(is_string($key) ? $key : '');
+        });
+
+        $this->app->singleton(TokenStore::class, function (Application $app): TokenStore {
+            $custom = $app->make(MagicLinkConfig::class)->tokenStore();
+
+            return $this->resolveContract($app, TokenStore::class, $custom, DefaultTokenStore::class);
+        });
+
+        $this->app->singleton(UserLookup::class, function (Application $app): UserLookup {
+            $custom = $app->make(MagicLinkConfig::class)->userLookup();
+
+            return $this->resolveContract($app, UserLookup::class, $custom, DefaultUserLookup::class);
+        });
+
+        $this->app->singleton(MagicLinkAuthenticator::class, DefaultAuthenticator::class);
+    }
+
+    public function boot(): void
+    {
+        $config = $this->app->make(MagicLinkConfig::class);
+
+        $this->registerPublishing();
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'email-magic-link');
+
+        if (self::$runsMigrations) {
+            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        }
+
+        // Decided at boot so published config is in force (the authenticator is
+        // only resolved at request time, after this wrapping is applied).
+        $this->registerFortifyBridge($config);
+
+        if (! $config->enabled()) {
+            return;
+        }
+
+        // Fail closed before anything user-facing is registered.
+        new EntropyGuard($config)->validate();
+
+        $this->registerRateLimiters($config);
+        $this->registerRoutes($config);
+    }
+
+    private function registerFortifyBridge(MagicLinkConfig $config): void
+    {
+        $mode = $config->fortifyMode();
+
+        if ($mode === false) {
+            return;
+        }
+
+        // Probed as a string so the core never references a Fortify symbol and
+        // stays loadable when Fortify is absent.
+        if (class_exists(self::$fortifyClass)) {
+            $this->app->register(FortifyBridgeServiceProvider::class);
+
+            return;
+        }
+
+        if ($mode === true) {
+            Log::warning(
+                '[email-magic-link] fortify.mode is true but laravel/fortify is not installed; the two-factor handoff is inactive.',
+            );
+        }
+    }
+
+    /**
+     * @template TContract of object
+     *
+     * @param  class-string<TContract>  $contract
+     * @param  class-string<TContract>  $default
+     * @return TContract
+     */
+    private function resolveContract(Application $app, string $contract, ?string $custom, string $default): object
+    {
+        $concrete = $custom ?? $default;
+        $instance = $app->make($concrete);
+
+        if ($instance instanceof $contract) {
+            return $instance;
+        }
+
+        throw new InvalidArgumentException("[{$concrete}] must implement [{$contract}].");
+    }
+
+    private function registerRoutes(MagicLinkConfig $config): void
+    {
+        if (! $this->app->routesAreCached()) {
+            Route::middleware($config->routeMiddleware())
+                ->prefix($config->routePrefix())
+                ->group(__DIR__.'/../routes/email-magic-link.php');
+        }
+    }
+
+    private function registerRateLimiters(MagicLinkConfig $config): void
+    {
+        $limits = $this->app->make(RateLimits::class);
+
+        RateLimiter::for($config->requestLimiter(), fn (Request $http): array => $limits->forRequest($http));
+        RateLimiter::for($config->consumeLimiter(), fn (Request $http): array => $limits->forConsume($http));
+    }
+
+    private function registerPublishing(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([PurgeExpiredTokensCommand::class]);
+
+            $this->publishes([
+                __DIR__.'/../config/email-magic-link.php' => config_path('email-magic-link.php'),
+            ], 'email-magic-link-config');
+
+            $this->publishes([
+                __DIR__.'/../database/migrations' => database_path('migrations'),
+            ], 'email-magic-link-migrations');
+
+            $this->publishes([
+                __DIR__.'/../resources/views' => resource_path('views/vendor/email-magic-link'),
+            ], 'email-magic-link-views');
+        }
+    }
+}

--- a/src/Events/MagicLinkRequested.php
+++ b/src/Events/MagicLinkRequested.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Events;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
+
+/**
+ * Fired when a link or code has been issued for a resolved user.
+ *
+ * Observability only: never dispatched for an unknown email, so it must not be
+ * used to decide whether an account exists in a response.
+ */
+final readonly class MagicLinkRequested
+{
+    public function __construct(
+        public Authenticatable $user,
+        public string $channel,
+        public Request $request,
+    ) {}
+}

--- a/src/Events/MagicLinkVerified.php
+++ b/src/Events/MagicLinkVerified.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Events;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
+
+/**
+ * Fired after a token has been verified and atomically consumed, before the
+ * authenticator runs.
+ *
+ * Fire-and-forget observability. It must never be used to control the
+ * login-versus-two-factor decision: a listener cannot reliably interrupt and
+ * redirect the response. Flow control lives in the MagicLinkAuthenticator.
+ */
+final readonly class MagicLinkVerified
+{
+    public function __construct(
+        public Authenticatable $user,
+        public Request $request,
+    ) {}
+}

--- a/src/Events/TwoFactorChallengeRequired.php
+++ b/src/Events/TwoFactorChallengeRequired.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Events;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
+
+/**
+ * Fired by the Fortify bridge when a verified user with confirmed TOTP is being
+ * handed off to the two-factor challenge instead of being logged in directly.
+ *
+ * Observability only: the user is not yet authenticated when this fires.
+ */
+final readonly class TwoFactorChallengeRequired
+{
+    public function __construct(
+        public Authenticatable $user,
+        public Request $request,
+    ) {}
+}

--- a/src/Exceptions/InsecureMagicLinkConfigurationException.php
+++ b/src/Exceptions/InsecureMagicLinkConfigurationException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown at boot when the magic-link configuration would be brute-forceable.
+ *
+ * The message always names the offending configuration keys and the minimum
+ * value that would satisfy the guardrail, so the adopter can fix it without
+ * understanding the underlying entropy math.
+ */
+final class InsecureMagicLinkConfigurationException extends RuntimeException {}

--- a/src/FortifyBridgeServiceProvider.php
+++ b/src/FortifyBridgeServiceProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink;
+
+use EmailMagicLink\Authenticators\FortifyAwareAuthenticator;
+use EmailMagicLink\Contracts\MagicLinkAuthenticator;
+use EmailMagicLink\Support\MagicLinkConfig;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\ServiceProvider;
+use Override;
+
+/**
+ * Activates the optional Fortify two-factor handoff.
+ *
+ * Registered by the core provider only when Fortify is installed and the bridge
+ * is enabled. It wraps the bound MagicLinkAuthenticator with the Fortify-aware
+ * decorator so a confirmed-2FA user is routed through Fortify's challenge. This
+ * file is the only one that participates in the Fortify-internal coupling.
+ */
+final class FortifyBridgeServiceProvider extends ServiceProvider
+{
+    #[Override]
+    public function register(): void
+    {
+        $this->app->extend(
+            MagicLinkAuthenticator::class,
+            fn (MagicLinkAuthenticator $default, Application $app): FortifyAwareAuthenticator => new FortifyAwareAuthenticator(
+                $default,
+                $app->make(MagicLinkConfig::class),
+            ),
+        );
+    }
+
+    public function boot(): void
+    {
+        $config = $this->app->make(MagicLinkConfig::class);
+
+        if ($config->enabled() && ! $config->respectTwoFactor()) {
+            Log::warning(
+                '[email-magic-link] fortify.respect_two_factor is disabled: magic-link logins skip the two-factor challenge for users who have it enabled.',
+            );
+        }
+    }
+}

--- a/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
+++ b/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Controllers\Concerns;
+
+use EmailMagicLink\Contracts\MagicLinkAuthenticator;
+use EmailMagicLink\Events\MagicLinkVerified;
+use EmailMagicLink\Models\MagicLinkToken;
+use Illuminate\Auth\AuthManager;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Shared post-verification flow for the consume endpoints.
+ *
+ * The verified user is loaded through the same guard provider that issued the
+ * token, the observability event is fired, and the swappable authenticator
+ * decides what happens next (log in, or hand off to a second factor).
+ */
+trait CompletesMagicLinkLogin
+{
+    use RespondsToApiClients;
+
+    protected function completeLogin(Request $request, MagicLinkToken $token, string $failureRoute): Response
+    {
+        $user = $this->resolveUser($token);
+
+        if ($user === null) {
+            return $this->failedConsumption($request, $failureRoute);
+        }
+
+        event(new MagicLinkVerified($user, $request));
+
+        return app(MagicLinkAuthenticator::class)->authenticate($request, $user, false);
+    }
+
+    protected function resolveUser(MagicLinkToken $token): ?Authenticatable
+    {
+        $providerName = config("auth.guards.{$token->guard}.provider");
+
+        return app(AuthManager::class)
+            ->createUserProvider(is_string($providerName) ? $providerName : null)
+            ?->retrieveById($token->user_id);
+    }
+
+    protected function failedConsumption(Request $request, string $failureRoute): Response
+    {
+        $message = 'This sign-in request is invalid or has expired. Please request a new one.';
+
+        if ($this->wantsJson($request)) {
+            return response()->json(['message' => $message], 422);
+        }
+
+        return redirect()->route($failureRoute)->withErrors(['email' => $message]);
+    }
+}

--- a/src/Http/Controllers/Concerns/RespondsToApiClients.php
+++ b/src/Http/Controllers/Concerns/RespondsToApiClients.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Controllers\Concerns;
+
+use EmailMagicLink\Support\MagicLinkConfig;
+use Illuminate\Http\Request;
+
+/**
+ * Decides whether a request should receive the JSON token-exchange variant.
+ *
+ * JSON is returned only when the client asks for it and the API variant is
+ * explicitly enabled; otherwise the secure browser flow (redirects and the
+ * confirmation interstitial) remains in force.
+ */
+trait RespondsToApiClients
+{
+    protected function wantsJson(Request $request): bool
+    {
+        return $request->expectsJson() && app(MagicLinkConfig::class)->apiEnabled();
+    }
+}

--- a/src/Http/Controllers/ConfirmMagicLinkController.php
+++ b/src/Http/Controllers/ConfirmMagicLinkController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Controllers;
+
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+
+/**
+ * Renders the inert confirmation interstitial for a magic link.
+ *
+ * This GET endpoint performs no consumption, no authentication, and no state
+ * change. It only renders a page whose CSRF-protected form POSTs to the consume
+ * route, so email security scanners and browser prefetch cannot burn the
+ * single-use token by merely following the link.
+ */
+final readonly class ConfirmMagicLinkController
+{
+    public function __construct(private Factory $views) {}
+
+    public function __invoke(string $token): View
+    {
+        return $this->views->make('email-magic-link::confirm', [
+            'token' => $token,
+            'action' => route('email-magic-link.consume', ['token' => $token]),
+        ]);
+    }
+}

--- a/src/Http/Controllers/ConsumeCodeController.php
+++ b/src/Http/Controllers/ConsumeCodeController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Controllers;
+
+use EmailMagicLink\Contracts\TokenStore;
+use EmailMagicLink\Contracts\UserLookup;
+use EmailMagicLink\Http\Controllers\Concerns\CompletesMagicLinkLogin;
+use EmailMagicLink\Http\Requests\ConsumeCodeRequest;
+use EmailMagicLink\Models\MagicLinkToken;
+use EmailMagicLink\Support\MagicLinkConfig;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Consumes a one-time code (email + code).
+ *
+ * The user is resolved by email, then the code is verified and atomically
+ * claimed with per-token attempt accounting and lockout. Every failure
+ * collapses to one generic message so neither account existence nor "wrong
+ * code versus no code" leaks.
+ */
+final class ConsumeCodeController
+{
+    use CompletesMagicLinkLogin;
+
+    public function __invoke(
+        ConsumeCodeRequest $request,
+        UserLookup $lookup,
+        TokenStore $store,
+        MagicLinkConfig $config,
+    ): Response {
+        $user = $lookup->findByEmail($request->email(), $config->guard());
+
+        if (! $user instanceof Authenticatable) {
+            return $this->failedConsumption($request, 'email-magic-link.code.form');
+        }
+
+        $result = $store->claimCode($user, $request->code());
+        $claimed = $result->token;
+
+        if (! $result->successful || ! $claimed instanceof MagicLinkToken) {
+            return $this->failedConsumption($request, 'email-magic-link.code.form');
+        }
+
+        return $this->completeLogin($request, $claimed, 'email-magic-link.code.form');
+    }
+}

--- a/src/Http/Controllers/ConsumeMagicLinkController.php
+++ b/src/Http/Controllers/ConsumeMagicLinkController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Controllers;
+
+use EmailMagicLink\Contracts\TokenStore;
+use EmailMagicLink\Http\Controllers\Concerns\CompletesMagicLinkLogin;
+use EmailMagicLink\Models\MagicLinkToken;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Consumes a magic-link token — the only side-effecting step of the link flow.
+ *
+ * The token is verified and atomically claimed here; only this POST mutates
+ * state. On success the swappable authenticator decides login versus 2FA.
+ */
+final class ConsumeMagicLinkController
+{
+    use CompletesMagicLinkLogin;
+
+    public function __invoke(Request $request, string $token, TokenStore $store): Response
+    {
+        $result = $store->claimLink($token);
+        $claimed = $result->token;
+
+        if (! $result->successful || ! $claimed instanceof MagicLinkToken) {
+            return $this->failedConsumption($request, 'email-magic-link.request.form');
+        }
+
+        return $this->completeLogin($request, $claimed, 'email-magic-link.request.form');
+    }
+}

--- a/src/Http/Controllers/SendMagicLinkController.php
+++ b/src/Http/Controllers/SendMagicLinkController.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Controllers;
+
+use EmailMagicLink\Contracts\TokenStore;
+use EmailMagicLink\Contracts\UserLookup;
+use EmailMagicLink\Events\MagicLinkRequested;
+use EmailMagicLink\Http\Controllers\Concerns\RespondsToApiClients;
+use EmailMagicLink\Http\Requests\SendMagicLinkRequest;
+use EmailMagicLink\Notifications\MagicLinkNotification;
+use EmailMagicLink\Support\IssuedToken;
+use EmailMagicLink\Support\MagicLinkConfig;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Notification as NotificationSender;
+use Illuminate\Support\Facades\URL;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Issues a magic link or code for a submitted email.
+ *
+ * Enumeration-resistant: the response is identical whether or not the
+ * email belongs to a user. A token is issued and a queued notification
+ * dispatched only when a user is found, but the caller can never observe that.
+ */
+final class SendMagicLinkController
+{
+    use RespondsToApiClients;
+
+    public function __invoke(
+        SendMagicLinkRequest $request,
+        UserLookup $lookup,
+        TokenStore $store,
+        MagicLinkConfig $config,
+    ): Response {
+        $email = $request->email();
+        $channel = $this->resolveChannel($request->requestedChannel(), $config->mode());
+        $guard = $config->guard();
+
+        $user = $lookup->findByEmail($email, $guard);
+
+        if ($user instanceof Authenticatable) {
+            $issued = $store->issue($user, $guard, $channel);
+
+            NotificationSender::route('mail', $email)
+                ->notify($this->buildNotification($issued, $channel, $config));
+
+            event(new MagicLinkRequested($user, $channel, $request));
+        }
+
+        return $this->sentResponse($request, $channel, $email);
+    }
+
+    /**
+     * @param  'link'|'code'|'both'  $mode
+     * @return 'link'|'code'
+     */
+    private function resolveChannel(?string $requested, string $mode): string
+    {
+        return match ($mode) {
+            'code' => 'code',
+            'both' => $requested === 'code' ? 'code' : 'link',
+            default => 'link',
+        };
+    }
+
+    /**
+     * @param  'link'|'code'  $channel
+     */
+    private function buildNotification(IssuedToken $issued, string $channel, MagicLinkConfig $config): MagicLinkNotification
+    {
+        $minutes = (int) ceil($config->ttl() / 60);
+
+        $actionUrl = $channel === 'link'
+            ? URL::temporarySignedRoute(
+                'email-magic-link.confirm',
+                $issued->record->expires_at,
+                ['token' => $issued->plaintext],
+            )
+            : null;
+
+        $notification = $config->notification();
+
+        return new $notification(
+            $channel,
+            $actionUrl,
+            $channel === 'code' ? $issued->plaintext : null,
+            $minutes,
+        );
+    }
+
+    /**
+     * @param  'link'|'code'  $channel
+     */
+    private function sentResponse(SendMagicLinkRequest $request, string $channel, string $email): Response
+    {
+        $message = $channel === 'code'
+            ? 'If an account matches that email, we have sent a sign-in code.'
+            : 'If an account matches that email, we have sent a sign-in link.';
+
+        if ($this->wantsJson($request)) {
+            return response()->json(['message' => $message, 'channel' => $channel]);
+        }
+
+        if ($channel === 'code') {
+            return redirect()->route('email-magic-link.code.form', ['email' => $email])
+                ->with('status', $message);
+        }
+
+        return redirect()->route('email-magic-link.request.form')->with('status', $message);
+    }
+}

--- a/src/Http/Controllers/ShowCodeFormController.php
+++ b/src/Http/Controllers/ShowCodeFormController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Controllers;
+
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+
+/**
+ * Renders the form where a user enters the one-time code (code mode).
+ */
+final readonly class ShowCodeFormController
+{
+    public function __construct(private Factory $views) {}
+
+    public function __invoke(Request $request): View
+    {
+        $email = $request->query('email');
+
+        return $this->views->make('email-magic-link::code', [
+            'email' => is_string($email) ? $email : '',
+        ]);
+    }
+}

--- a/src/Http/Controllers/ShowRequestFormController.php
+++ b/src/Http/Controllers/ShowRequestFormController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Controllers;
+
+use EmailMagicLink\Support\MagicLinkConfig;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+
+/**
+ * Renders the "enter your email" form that starts the flow.
+ */
+final readonly class ShowRequestFormController
+{
+    public function __construct(
+        private MagicLinkConfig $config,
+        private Factory $views,
+    ) {}
+
+    public function __invoke(): View
+    {
+        return $this->views->make('email-magic-link::request', ['mode' => $this->config->mode()]);
+    }
+}

--- a/src/Http/Requests/ConsumeCodeRequest.php
+++ b/src/Http/Requests/ConsumeCodeRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Override;
+
+/**
+ * Validates a one-time code submission (email + code).
+ *
+ * Open authorization for the same reason as the request endpoint: the caller is
+ * an unauthenticated guest. Correctness of the code itself is verified by the
+ * token store's constant-time hash comparison, not here.
+ */
+final class ConsumeCodeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email', 'max:255'],
+            'code' => ['required', 'string', 'max:255'],
+        ];
+    }
+
+    #[Override]
+    protected function prepareForValidation(): void
+    {
+        $email = $this->input('email');
+        $code = $this->input('code');
+
+        $this->merge([
+            'email' => is_string($email) ? mb_strtolower(trim($email)) : $email,
+            'code' => is_string($code) ? strtoupper(preg_replace('/\s+/u', '', $code) ?? $code) : $code,
+        ]);
+    }
+
+    public function email(): string
+    {
+        $email = $this->validated('email');
+
+        return is_string($email) ? $email : '';
+    }
+
+    public function code(): string
+    {
+        $code = $this->validated('code');
+
+        return is_string($code) ? $code : '';
+    }
+}

--- a/src/Http/Requests/SendMagicLinkRequest.php
+++ b/src/Http/Requests/SendMagicLinkRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Override;
+
+/**
+ * Validates a request to issue a magic link or code.
+ *
+ * Authorization is intentionally open: this is a pre-authentication endpoint
+ * reachable by guests, so there is no actor or model to gate with a policy.
+ */
+final class SendMagicLinkRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email', 'max:255'],
+            'channel' => ['sometimes', 'nullable', 'string', Rule::in(['link', 'code'])],
+        ];
+    }
+
+    #[Override]
+    protected function prepareForValidation(): void
+    {
+        $email = $this->input('email');
+
+        if (is_string($email)) {
+            $this->merge(['email' => mb_strtolower(trim($email))]);
+        }
+    }
+
+    public function email(): string
+    {
+        $email = $this->validated('email');
+
+        return is_string($email) ? $email : '';
+    }
+
+    public function requestedChannel(): ?string
+    {
+        $channel = $this->validated('channel');
+
+        return is_string($channel) && $channel !== '' ? $channel : null;
+    }
+}

--- a/src/Lookups/DefaultUserLookup.php
+++ b/src/Lookups/DefaultUserLookup.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Lookups;
+
+use EmailMagicLink\Contracts\UserLookup;
+use Illuminate\Auth\AuthManager;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Config\Repository;
+
+/**
+ * Resolves a user through the guard's configured user provider.
+ *
+ * Uses retrieveByCredentials so the lookup honours the application's provider
+ * (Eloquent or database), model, and connection. A miss returns null with the
+ * same single-query shape as a hit, keeping the request endpoint
+ * enumeration-resistant.
+ */
+final readonly class DefaultUserLookup implements UserLookup
+{
+    public function __construct(
+        private AuthManager $auth,
+        private Repository $config,
+    ) {}
+
+    public function findByEmail(string $email, string $guard): ?Authenticatable
+    {
+        $provider = $this->config->get("auth.guards.{$guard}.provider");
+        $provider = is_string($provider) && $provider !== '' ? $provider : null;
+
+        return $this->auth->createUserProvider($provider)
+            ?->retrieveByCredentials(['email' => $email]);
+    }
+}

--- a/src/Models/MagicLinkToken.php
+++ b/src/Models/MagicLinkToken.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Override;
+
+/**
+ * A single issued magic link or one-time code.
+ *
+ * Only the keyed hash of the secret is stored. The row is the unit the atomic
+ * single-use claim operates on.
+ *
+ * @property int $id
+ * @property string $user_id
+ * @property string $guard
+ * @property string $token_hash
+ * @property string $channel
+ * @property int $attempts
+ * @property Carbon $expires_at
+ * @property Carbon|null $consumed_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
+class MagicLinkToken extends Model
+{
+    protected $table = 'magic_link_tokens';
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'guard',
+        'token_hash',
+        'channel',
+        'attempts',
+        'expires_at',
+        'consumed_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    #[Override]
+    protected function casts(): array
+    {
+        return [
+            'attempts' => 'integer',
+            'expires_at' => 'datetime',
+            'consumed_at' => 'datetime',
+        ];
+    }
+
+    public function isExpired(?Carbon $now = null): bool
+    {
+        return $this->expires_at->lessThanOrEqualTo($now ?? Carbon::now());
+    }
+
+    public function isConsumed(): bool
+    {
+        return $this->consumed_at !== null;
+    }
+}

--- a/src/Notifications/MagicLinkNotification.php
+++ b/src/Notifications/MagicLinkNotification.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Delivers a magic link or one-time code over the mail channel.
+ *
+ * Queued so the request that issues it returns without waiting on the mailer,
+ * which keeps the request endpoint's timing independent of whether a user was
+ * found. It carries only the already-built action URL or code, never internals.
+ */
+class MagicLinkNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @param  'link'|'code'  $channel
+     */
+    public function __construct(
+        public readonly string $channel,
+        public readonly ?string $actionUrl,
+        public readonly ?string $code,
+        public readonly int $expiresInMinutes,
+    ) {}
+
+    /**
+     * @return list<string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $application = config('app.name');
+        $application = is_string($application) && $application !== '' ? $application : 'this application';
+
+        return $this->channel === 'code'
+            ? $this->codeMessage($application)
+            : $this->linkMessage($application);
+    }
+
+    private function linkMessage(string $application): MailMessage
+    {
+        return (new MailMessage)
+            ->subject("Sign in to {$application}")
+            ->line("Use the button below to sign in to {$application}.")
+            ->action('Sign in', (string) $this->actionUrl)
+            ->line("This link expires in {$this->expiresInMinutes} minutes and can be used once.")
+            ->line('If you did not request this, you can safely ignore this email.');
+    }
+
+    private function codeMessage(string $application): MailMessage
+    {
+        return (new MailMessage)
+            ->subject("Your {$application} sign-in code")
+            ->line("Your sign-in code for {$application} is:")
+            ->line((string) $this->code)
+            ->line("This code expires in {$this->expiresInMinutes} minutes.")
+            ->line('If you did not request this, you can safely ignore this email.');
+    }
+}

--- a/src/Stores/DefaultTokenStore.php
+++ b/src/Stores/DefaultTokenStore.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Stores;
+
+use EmailMagicLink\Contracts\TokenStore;
+use EmailMagicLink\Models\MagicLinkToken;
+use EmailMagicLink\Support\ClaimFailure;
+use EmailMagicLink\Support\ClaimResult;
+use EmailMagicLink\Support\IssuedToken;
+use EmailMagicLink\Support\MagicLinkConfig;
+use EmailMagicLink\Support\TokenHasher;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+
+/**
+ * Eloquent-backed token store.
+ *
+ * Tokens are stored only as keyed hashes. Consumption is a single conditional
+ * UPDATE so two concurrent claims for the same token can never both win:
+ * PostgreSQL uses RETURNING, every other driver checks the affected-row count.
+ */
+final readonly class DefaultTokenStore implements TokenStore
+{
+    public function __construct(
+        private MagicLinkConfig $config,
+        private TokenHasher $hasher,
+    ) {}
+
+    public function issue(Authenticatable $user, string $guard, string $channel): IssuedToken
+    {
+        $now = Carbon::now();
+        $userId = $this->identifierOf($user);
+
+        if ($channel === 'code') {
+            // Keep at most one active code per user so a claim is unambiguous.
+            MagicLinkToken::query()
+                ->where('user_id', $userId)
+                ->where('channel', 'code')
+                ->whereNull('consumed_at')
+                ->update(['consumed_at' => $now]);
+        }
+
+        $plaintext = $channel === 'code' ? $this->generateCode() : $this->generateLinkToken();
+
+        $record = new MagicLinkToken;
+        $record->user_id = $userId;
+        $record->guard = $guard;
+        $record->token_hash = $this->hasher->hash($plaintext);
+        $record->channel = $channel;
+        $record->attempts = 0;
+        $record->expires_at = $now->copy()->addSeconds($this->config->ttl());
+        $record->consumed_at = null;
+        $record->save();
+
+        return new IssuedToken($plaintext, $record);
+    }
+
+    public function claimLink(string $token): ClaimResult
+    {
+        $now = Carbon::now();
+        $hash = $this->hasher->hash($token);
+
+        if ($this->atomicClaim('token_hash', $hash, 'link', $now)) {
+            $model = MagicLinkToken::query()
+                ->where('token_hash', $hash)
+                ->where('channel', 'link')
+                ->first();
+
+            return $model !== null
+                ? ClaimResult::success($model)
+                : ClaimResult::failed(ClaimFailure::NotFound);
+        }
+
+        return ClaimResult::failed($this->classifyLinkFailure($hash, $now));
+    }
+
+    public function claimCode(Authenticatable $user, string $code): ClaimResult
+    {
+        $now = Carbon::now();
+        $max = $this->config->maxAttemptsPerToken();
+
+        $token = MagicLinkToken::query()
+            ->where('user_id', $this->identifierOf($user))
+            ->where('channel', 'code')
+            ->whereNull('consumed_at')
+            ->orderByDesc('id')
+            ->first();
+
+        if ($token === null) {
+            return ClaimResult::failed(ClaimFailure::NotFound);
+        }
+
+        if ($token->isExpired($now)) {
+            return ClaimResult::failed(ClaimFailure::Expired);
+        }
+
+        if ($token->attempts >= $max) {
+            return ClaimResult::failed(ClaimFailure::LockedOut);
+        }
+
+        if (! $this->hasher->matches($code, $token->token_hash)) {
+            return $this->recordFailedCodeAttempt($token, $max, $now);
+        }
+
+        if (! $this->atomicClaim('id', (string) $token->id, 'code', $now)) {
+            // Only reachable when a concurrent request consumes this same token
+            // between the lookup above and this claim. The single conditional
+            // UPDATE in atomicClaim() is what makes that race safe; this branch
+            // just maps the losing request's outcome.
+            return ClaimResult::failed(ClaimFailure::AlreadyConsumed); // @codeCoverageIgnore
+        }
+
+        $token->consumed_at = $now;
+
+        return ClaimResult::success($token);
+    }
+
+    public function purge(): int
+    {
+        $deleted = MagicLinkToken::query()
+            ->where(function (Builder $query): void {
+                $query->where('expires_at', '<=', Carbon::now())
+                    ->orWhereNotNull('consumed_at');
+            })
+            ->delete();
+
+        return is_int($deleted) ? $deleted : 0;
+    }
+
+    private function recordFailedCodeAttempt(MagicLinkToken $token, int $max, Carbon $now): ClaimResult
+    {
+        $connection = $this->connection();
+
+        $connection->table('magic_link_tokens')
+            ->where('id', $token->id)
+            ->whereNull('consumed_at')
+            ->increment('attempts', 1, ['updated_at' => $now]);
+
+        $attempts = $connection->table('magic_link_tokens')
+            ->where('id', $token->id)
+            ->value('attempts');
+        $attempts = is_numeric($attempts) ? (int) $attempts : 0;
+
+        if ($attempts >= $max) {
+            // Burn the token: the lockout, not the rate limiter, bounds brute force.
+            // updated_at was already bumped by the increment above.
+            $connection->table('magic_link_tokens')
+                ->where('id', $token->id)
+                ->whereNull('consumed_at')
+                ->update(['consumed_at' => $now]);
+
+            return ClaimResult::failed(ClaimFailure::LockedOut);
+        }
+
+        return ClaimResult::failed(ClaimFailure::InvalidCode);
+    }
+
+    /**
+     * Atomically flip consumed_at on the single active row matching the column.
+     *
+     * Returns true only for the request that wins the race.
+     */
+    private function atomicClaim(string $column, string $value, string $channel, Carbon $now): bool
+    {
+        $connection = $this->connection();
+
+        if ($connection->getDriverName() === 'pgsql') {
+            $returned = $connection->select(
+                "update magic_link_tokens set consumed_at = ?, updated_at = ? where {$column} = ? and channel = ? and consumed_at is null and expires_at > ? returning id",
+                [$now, $now, $value, $channel, $now],
+            );
+
+            return $returned !== [];
+        }
+
+        return $connection->table('magic_link_tokens')
+            ->where($column, $value)
+            ->where('channel', $channel)
+            ->whereNull('consumed_at')
+            ->where('expires_at', '>', $now)
+            ->update(['consumed_at' => $now, 'updated_at' => $now]) === 1;
+    }
+
+    private function classifyLinkFailure(string $hash, Carbon $now): ClaimFailure
+    {
+        $row = MagicLinkToken::query()
+            ->where('token_hash', $hash)
+            ->where('channel', 'link')
+            ->first();
+
+        return match (true) {
+            $row === null => ClaimFailure::NotFound,
+            $row->isConsumed() => ClaimFailure::AlreadyConsumed,
+            $row->isExpired($now) => ClaimFailure::Expired,
+            default => ClaimFailure::NotFound,
+        };
+    }
+
+    private function generateLinkToken(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+    }
+
+    private function generateCode(): string
+    {
+        // The same canonical distinct-character set the entropy guardrail
+        // certifies, so the generated distribution matches the proven keyspace.
+        $characters = $this->config->codeAlphabetCharacters();
+        $length = $this->config->codeLength();
+        $bound = count($characters) - 1;
+
+        $code = '';
+        for ($i = 0; $i < $length; $i++) {
+            $code .= $characters[random_int(0, $bound)];
+        }
+
+        return $code;
+    }
+
+    private function connection(): Connection
+    {
+        return (new MagicLinkToken)->getConnection();
+    }
+
+    private function identifierOf(Authenticatable $user): string
+    {
+        $identifier = $user->getAuthIdentifier();
+
+        return is_scalar($identifier) ? (string) $identifier : '';
+    }
+}

--- a/src/Support/ClaimFailure.php
+++ b/src/Support/ClaimFailure.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+/**
+ * Why an attempt to claim a token did not succeed.
+ *
+ * Deliberately coarse: the HTTP layer collapses every failure into one generic
+ * message so a caller can never distinguish "wrong code" from "no such token".
+ */
+enum ClaimFailure
+{
+    case NotFound;
+    case Expired;
+    case AlreadyConsumed;
+    case InvalidCode;
+    case LockedOut;
+}

--- a/src/Support/ClaimResult.php
+++ b/src/Support/ClaimResult.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use EmailMagicLink\Models\MagicLinkToken;
+
+/**
+ * Outcome of an atomic claim: either the consumed token, or the reason it failed.
+ */
+final readonly class ClaimResult
+{
+    private function __construct(
+        public bool $successful,
+        public ?MagicLinkToken $token,
+        public ?ClaimFailure $failure,
+    ) {}
+
+    public static function success(MagicLinkToken $token): self
+    {
+        return new self(true, $token, null);
+    }
+
+    public static function failed(ClaimFailure $failure): self
+    {
+        return new self(false, null, $failure);
+    }
+}

--- a/src/Support/EntropyGuard.php
+++ b/src/Support/EntropyGuard.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use EmailMagicLink\Exceptions\InsecureMagicLinkConfigurationException;
+
+/**
+ * Boot-time, fail-closed configuration guardrail.
+ *
+ * Magic links carry 256 bits of entropy and pass trivially. Short codes do not:
+ * their brute-force resistance is keyspace / attempts-per-token, and this guard
+ * refuses to boot a configuration where that ratio falls below the safety
+ * factor — protecting adopters who never read the entropy math.
+ */
+final readonly class EntropyGuard
+{
+    /**
+     * The lowest safety factor that may be configured. The check cannot be
+     * weakened below this floor, only made stricter.
+     */
+    public const int MINIMUM_SAFETY_FACTOR = 1_000_000;
+
+    public function __construct(private MagicLinkConfig $config) {}
+
+    public function validate(): void
+    {
+        $ttl = $this->config->ttl();
+
+        if ($ttl <= 0) {
+            throw new InsecureMagicLinkConfigurationException(
+                "email-magic-link.ttl must be greater than zero; [{$ttl}] given.",
+            );
+        }
+
+        // Link tokens are 256-bit by construction; only code mode needs the check.
+        if ($this->config->mode() === 'link') {
+            return;
+        }
+
+        $this->validateCodeKeyspace();
+    }
+
+    private function validateCodeKeyspace(): void
+    {
+        $alphabetSize = count($this->config->codeAlphabetCharacters());
+        $length = $this->config->codeLength();
+        $maxAttempts = $this->config->maxAttemptsPerToken();
+        $safetyFactor = $this->config->entropySafetyFactor();
+
+        if ($alphabetSize < 2) {
+            throw new InsecureMagicLinkConfigurationException(
+                'email-magic-link.code_alphabet must contain at least 2 distinct characters in code mode.',
+            );
+        }
+
+        if ($length < 1) {
+            throw new InsecureMagicLinkConfigurationException(
+                "email-magic-link.code_length must be at least 1 in code mode; [{$length}] given.",
+            );
+        }
+
+        if ($maxAttempts < 1) {
+            throw new InsecureMagicLinkConfigurationException(
+                'email-magic-link.max_attempts_per_token must be set to at least 1 in code mode.',
+            );
+        }
+
+        if ($safetyFactor < self::MINIMUM_SAFETY_FACTOR) {
+            throw new InsecureMagicLinkConfigurationException(sprintf(
+                'email-magic-link.entropy_safety_factor must be at least %s; [%s] given. The guardrail cannot be weakened below this floor.',
+                number_format(self::MINIMUM_SAFETY_FACTOR),
+                number_format($safetyFactor),
+            ));
+        }
+
+        $keyspace = $alphabetSize ** $length;
+        $required = $safetyFactor * $maxAttempts;
+
+        if ($keyspace < $required) {
+            $minLength = (int) ceil(log($required, $alphabetSize));
+
+            $odds = $keyspace <= $maxAttempts
+                ? 'an attacker can exhaust the entire keyspace within the allowed attempts (near-certain success)'
+                : sprintf(
+                    'permits roughly a 1-in-%s chance of success within %d attempts',
+                    number_format($keyspace / $maxAttempts),
+                    $maxAttempts,
+                );
+
+            throw new InsecureMagicLinkConfigurationException(sprintf(
+                'The configured one-time code is brute-forceable: a %d-character code over a %d-character alphabet %s, below the required 1-in-%s (email-magic-link.entropy_safety_factor). Increase email-magic-link.code_length to at least %d, enlarge email-magic-link.code_alphabet, or lower email-magic-link.max_attempts_per_token.',
+                $length,
+                $alphabetSize,
+                $odds,
+                number_format($safetyFactor),
+                $minLength,
+            ));
+        }
+    }
+}

--- a/src/Support/IssuedToken.php
+++ b/src/Support/IssuedToken.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use EmailMagicLink\Models\MagicLinkToken;
+
+/**
+ * A freshly issued token: the plaintext secret to deliver, plus its stored row.
+ *
+ * The plaintext exists only in memory for the lifetime of the request that
+ * issues it. Only the keyed hash on the record is ever persisted.
+ */
+final readonly class IssuedToken
+{
+    public function __construct(
+        public string $plaintext,
+        public MagicLinkToken $record,
+    ) {}
+}

--- a/src/Support/MagicLinkConfig.php
+++ b/src/Support/MagicLinkConfig.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use EmailMagicLink\Notifications\MagicLinkNotification;
+use Illuminate\Contracts\Config\Repository;
+
+/**
+ * Typed gateway to the package configuration.
+ *
+ * Every configuration read in the package goes through here so the rest of the
+ * code never touches the loosely typed config repository directly.
+ */
+final readonly class MagicLinkConfig
+{
+    public function __construct(private Repository $config) {}
+
+    public function enabled(): bool
+    {
+        return $this->bool($this->config->get('email-magic-link.enabled'), true);
+    }
+
+    /**
+     * @return 'link'|'code'|'both'
+     */
+    public function mode(): string
+    {
+        return match ($this->string($this->config->get('email-magic-link.mode'), 'link')) {
+            'code' => 'code',
+            'both' => 'both',
+            default => 'link',
+        };
+    }
+
+    public function ttl(): int
+    {
+        return $this->int($this->config->get('email-magic-link.ttl'), 900);
+    }
+
+    public function codeLength(): int
+    {
+        return $this->int($this->config->get('email-magic-link.code_length'), 8);
+    }
+
+    public function codeAlphabet(): string
+    {
+        return $this->string($this->config->get('email-magic-link.code_alphabet'), '');
+    }
+
+    /**
+     * The distinct characters of the code alphabet, multibyte-aware.
+     *
+     * Both the entropy guardrail and the code generator use this single
+     * canonical representation, so the keyspace the guard certifies is exactly
+     * the uniform distribution the generator emits.
+     *
+     * @return list<string>
+     */
+    public function codeAlphabetCharacters(): array
+    {
+        return array_values(array_unique(mb_str_split($this->codeAlphabet())));
+    }
+
+    public function maxAttemptsPerToken(): int
+    {
+        return $this->int($this->config->get('email-magic-link.max_attempts_per_token'), 0);
+    }
+
+    public function entropySafetyFactor(): int
+    {
+        return $this->int($this->config->get('email-magic-link.entropy_safety_factor'), 1_000_000);
+    }
+
+    public function guard(): string
+    {
+        $guard = $this->config->get('email-magic-link.guard');
+
+        if (is_string($guard) && $guard !== '') {
+            return $guard;
+        }
+
+        return $this->string($this->config->get('auth.defaults.guard'), 'web');
+    }
+
+    public function userLookup(): ?string
+    {
+        $lookup = $this->config->get('email-magic-link.user_lookup');
+
+        return is_string($lookup) && $lookup !== '' ? $lookup : null;
+    }
+
+    public function tokenStore(): ?string
+    {
+        $store = $this->config->get('email-magic-link.token_store');
+
+        return is_string($store) && $store !== '' ? $store : null;
+    }
+
+    /**
+     * @return class-string<MagicLinkNotification>
+     */
+    public function notification(): string
+    {
+        $notification = $this->config->get('email-magic-link.notification');
+
+        if (is_string($notification) && is_a($notification, MagicLinkNotification::class, true)) {
+            return $notification;
+        }
+
+        return MagicLinkNotification::class;
+    }
+
+    public function routePrefix(): string
+    {
+        return $this->string($this->config->get('email-magic-link.routes.prefix'), '');
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function routeMiddleware(): array
+    {
+        $middleware = $this->config->get('email-magic-link.routes.middleware');
+
+        if (! is_array($middleware)) {
+            return ['web'];
+        }
+
+        $result = [];
+
+        foreach ($middleware as $entry) {
+            if (is_string($entry) && $entry !== '') {
+                $result[] = $entry;
+            }
+        }
+
+        return $result === [] ? ['web'] : $result;
+    }
+
+    public function redirectTo(): string
+    {
+        return $this->string($this->config->get('email-magic-link.routes.redirect_to'), '/');
+    }
+
+    public function apiEnabled(): bool
+    {
+        return $this->bool($this->config->get('email-magic-link.api.enabled'), false);
+    }
+
+    /**
+     * @return 'auto'|bool
+     */
+    public function fortifyMode(): string|bool
+    {
+        $mode = $this->config->get('email-magic-link.fortify.mode', 'auto');
+
+        if (is_bool($mode)) {
+            return $mode;
+        }
+
+        return match ($mode) {
+            'false' => false,
+            'true' => true,
+            default => 'auto',
+        };
+    }
+
+    public function respectTwoFactor(): bool
+    {
+        return $this->bool($this->config->get('email-magic-link.fortify.respect_two_factor'), true);
+    }
+
+    public function challengeRoute(): string
+    {
+        return $this->string($this->config->get('email-magic-link.fortify.challenge_route'), 'two-factor.login');
+    }
+
+    public function requestLimiter(): string
+    {
+        return $this->string($this->config->get('email-magic-link.limiters.request'), 'email-magic-link:request');
+    }
+
+    public function consumeLimiter(): string
+    {
+        return $this->string($this->config->get('email-magic-link.limiters.consume'), 'email-magic-link:consume');
+    }
+
+    /**
+     * @return array{max: int, per_minutes: int}
+     */
+    public function requestLimit(): array
+    {
+        return $this->readLimit('request', 5);
+    }
+
+    /**
+     * @return array{max: int, per_minutes: int}
+     */
+    public function consumeLimit(): array
+    {
+        return $this->readLimit('consume', 10);
+    }
+
+    /**
+     * @return array{max: int, per_minutes: int}
+     */
+    private function readLimit(string $key, int $defaultMax): array
+    {
+        $limit = $this->config->get("email-magic-link.limits.{$key}");
+        $limit = is_array($limit) ? $limit : [];
+
+        return [
+            'max' => $this->int($limit['max'] ?? null, $defaultMax),
+            'per_minutes' => max(1, $this->int($limit['per_minutes'] ?? null, 1)),
+        ];
+    }
+
+    private function string(mixed $value, string $default): string
+    {
+        return is_string($value) ? $value : $default;
+    }
+
+    private function int(mixed $value, int $default): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        return is_string($value) && is_numeric($value) ? (int) $value : $default;
+    }
+
+    private function bool(mixed $value, bool $default): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if ($value === null) {
+            return $default;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/src/Support/RateLimits.php
+++ b/src/Support/RateLimits.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+
+/**
+ * Builds the named rate limiters for the request and consume endpoints.
+ *
+ * The request endpoint is throttled per email and per IP; the consume endpoint
+ * per IP and per token (keyed by the token hash, never the raw token).
+ */
+final readonly class RateLimits
+{
+    public function __construct(private MagicLinkConfig $config) {}
+
+    /**
+     * @return list<Limit>
+     */
+    public function forRequest(Request $request): array
+    {
+        $limit = $this->config->requestLimit();
+        $email = $request->input('email');
+        $email = is_string($email) ? mb_strtolower($email) : '';
+
+        return [
+            Limit::perMinutes($limit['per_minutes'], $limit['max'])->by('eml:req:email:'.$email),
+            Limit::perMinutes($limit['per_minutes'], $limit['max'])->by('eml:req:ip:'.($request->ip())),
+        ];
+    }
+
+    /**
+     * @return list<Limit>
+     */
+    public function forConsume(Request $request): array
+    {
+        $limit = $this->config->consumeLimit();
+        $token = $request->route('token');
+        $email = $request->input('email');
+
+        $discriminator = is_string($token) && $token !== ''
+            ? hash('sha256', $token)
+            : (is_string($email) ? mb_strtolower($email) : '');
+
+        return [
+            Limit::perMinutes($limit['per_minutes'], $limit['max'])->by('eml:con:ip:'.($request->ip())),
+            Limit::perMinutes($limit['per_minutes'], $limit['max'])->by('eml:con:id:'.$discriminator),
+        ];
+    }
+}

--- a/src/Support/TokenHasher.php
+++ b/src/Support/TokenHasher.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+/**
+ * Keyed hashing for token secrets.
+ *
+ * The application key is used as the HMAC key so a leaked database alone cannot
+ * be used to forge or recognize tokens. The raw secret is never stored.
+ */
+final readonly class TokenHasher
+{
+    public function __construct(private string $key) {}
+
+    public function hash(string $plaintext): string
+    {
+        return hash_hmac('sha256', $plaintext, $this->key);
+    }
+
+    public function matches(string $plaintext, string $expectedHash): bool
+    {
+        return hash_equals($expectedHash, $this->hash($plaintext));
+    }
+}


### PR DESCRIPTION

### Security

- Normalize the one-time-code regex with the `/u` flag for multibyte safety.

### Documentation

- Recommend layering a CAPTCHA on the request form for high-risk deployments.
