### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-06-22
+
+### Added
+
+- An `email-magic-link:install` command that publishes the configuration (and,
+  with `--views`, the Blade views) and prints the setup steps.
+
 ## [0.1.1] - 2026-06-22
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -30,17 +30,19 @@ The package requires `laravel/framework` (for the `FormRequest` base it validate
 composer require pushery/email-magic-link-for-laravel
 ```
 
-Publish and run the migration:
+Then run the installer to publish the configuration and print the next steps:
 
 ```bash
-php artisan vendor:publish --tag=email-magic-link-migrations
-php artisan migrate
+php artisan email-magic-link:install
 ```
 
-The migration is also auto-loaded, so a fresh app works without publishing. Optionally publish the config and views:
+Add `--views` to also publish the Blade views. The migration is loaded automatically, so a fresh app works without publishing anything.
+
+Prefer to do it by hand? The individual publish tags are still available:
 
 ```bash
 php artisan vendor:publish --tag=email-magic-link-config
+php artisan vendor:publish --tag=email-magic-link-migrations
 php artisan vendor:publish --tag=email-magic-link-views
 ```
 

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Console\Commands;
+
+use Illuminate\Console\Command;
+
+/**
+ * Publishes the configuration (and optionally the views) and prints the next steps.
+ *
+ * The migration is loaded automatically, so a fresh app works without publishing
+ * anything; this command is a convenience for customizing the config or views.
+ */
+final class InstallCommand extends Command
+{
+    protected $signature = 'email-magic-link:install
+        {--force : Overwrite existing published files}
+        {--views : Also publish the Blade views for customizing}';
+
+    protected $description = 'Publish the configuration and print the setup steps.';
+
+    public function handle(): int
+    {
+        $force = $this->option('force');
+
+        $this->callSilently('vendor:publish', [
+            '--tag' => 'email-magic-link-config',
+            '--force' => $force,
+        ]);
+        $this->info('Published config/email-magic-link.php');
+
+        if ($this->option('views')) {
+            $this->callSilently('vendor:publish', [
+                '--tag' => 'email-magic-link-views',
+                '--force' => $force,
+            ]);
+            $this->info('Published the views to resources/views/vendor/email-magic-link');
+        }
+
+        $this->newLine();
+        $this->info('Email Magic Link is ready.');
+        $this->line("Point your sign-in link at route('email-magic-link.request.form').");
+        $this->line('The migration is loaded automatically; publish it with');
+        $this->line('  php artisan vendor:publish --tag=email-magic-link-migrations');
+        $this->line('if you need to customize it.');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/EmailMagicLinkServiceProvider.php
+++ b/src/EmailMagicLinkServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EmailMagicLink;
 
 use EmailMagicLink\Authenticators\DefaultAuthenticator;
+use EmailMagicLink\Console\Commands\InstallCommand;
 use EmailMagicLink\Console\Commands\PurgeExpiredTokensCommand;
 use EmailMagicLink\Contracts\MagicLinkAuthenticator;
 use EmailMagicLink\Contracts\TokenStore;
@@ -163,7 +164,10 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
     private function registerPublishing(): void
     {
         if ($this->app->runningInConsole()) {
-            $this->commands([PurgeExpiredTokensCommand::class]);
+            $this->commands([
+                InstallCommand::class,
+                PurgeExpiredTokensCommand::class,
+            ]);
 
             $this->publishes([
                 __DIR__.'/../config/email-magic-link.php' => config_path('email-magic-link.php'),


### PR DESCRIPTION

### Added

- An `email-magic-link:install` command that publishes the configuration (and,
  with `--views`, the Blade views) and prints the setup steps.
