### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-06-22
+
+### Added
+
+- Translatable user-facing strings: the views and the mail notification now resolve
+  every string through the `email-magic-link` translation namespace, with publishable
+  language files (`--tag=email-magic-link-lang`).
+
 ## [0.2.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -134,6 +134,21 @@ use Illuminate\Support\Facades\Schedule;
 Schedule::command('email-magic-link:purge')->daily();
 ```
 
+## Translations
+
+Every user-facing string — in the views and the notification — runs through
+Laravel's translator under the `email-magic-link` namespace, so the package ships
+in English and adapts to the application's active locale. Publish the language
+files to translate or reword them:
+
+```bash
+php artisan vendor:publish --tag=email-magic-link-lang
+```
+
+That copies the strings to `lang/vendor/email-magic-link/{locale}`. Add a locale
+by copying the `en` directory (for example to `de`) and translating the values;
+the `:app` and `:minutes` placeholders are filled in at render time.
+
 ## Extension points
 
 **Take over the post-verification flow** by rebinding the authenticator contract:

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // Shared.
+    'heading' => 'Sign in to :app',
+    'email_label' => 'Email address',
+    'sign_in' => 'Sign in',
+
+    // Request form.
+    'request_title' => 'Sign in',
+    'request_intro_link' => 'Enter your email address and we will send you a secure sign-in link.',
+    'request_intro_code' => 'Enter your email address and we will send you a secure sign-in code.',
+    'request_send_link' => 'Send sign-in link',
+    'request_send_code' => 'Send sign-in code',
+    'delivery_legend' => 'Delivery',
+    'delivery_link' => 'Magic link',
+    'delivery_code' => 'One-time code',
+
+    // Confirmation page.
+    'confirm_title' => 'Confirm sign in',
+    'confirm_intro' => 'For your security, confirm that you want to sign in. This link can only be used once.',
+
+    // Code entry form.
+    'code_title' => 'Enter your code',
+    'code_heading' => 'Enter your sign-in code',
+    'code_intro' => 'We emailed you a one-time code. Enter it below to finish signing in.',
+    'code_label' => 'Sign-in code',
+
+    // Notification — magic link.
+    'mail_link_subject' => 'Sign in to :app',
+    'mail_link_intro' => 'Use the button below to sign in to :app.',
+    'mail_link_action' => 'Sign in',
+    'mail_link_expiry' => 'This link expires in :minutes minutes and can be used once.',
+
+    // Notification — one-time code.
+    'mail_code_subject' => 'Your :app sign-in code',
+    'mail_code_intro' => 'Your sign-in code for :app is:',
+    'mail_code_expiry' => 'This code expires in :minutes minutes.',
+
+    // Notification — shared.
+    'mail_ignore' => 'If you did not request this, you can safely ignore this email.',
+];

--- a/resources/views/code.blade.php
+++ b/resources/views/code.blade.php
@@ -1,10 +1,10 @@
 @extends('email-magic-link::layout')
 
-@section('title', 'Enter your code')
+@section('title', __('email-magic-link::messages.code_title'))
 
 @section('content')
-    <h1>Enter your sign-in code</h1>
-    <p>We emailed you a one-time code. Enter it below to finish signing in.</p>
+    <h1>{{ __('email-magic-link::messages.code_heading') }}</h1>
+    <p>{{ __('email-magic-link::messages.code_intro') }}</p>
 
     @if (session('status'))
         <div class="status" role="status">{{ session('status') }}</div>
@@ -13,10 +13,10 @@
     <form method="POST" action="{{ route('email-magic-link.code.consume') }}">
         @csrf
 
-        <label for="email">Email address</label>
+        <label for="email">{{ __('email-magic-link::messages.email_label') }}</label>
         <input id="email" name="email" type="email" autocomplete="email" required value="{{ $email ?: old('email') }}">
 
-        <label for="code" style="margin-top:1rem">Sign-in code</label>
+        <label for="code" style="margin-top:1rem">{{ __('email-magic-link::messages.code_label') }}</label>
         <input id="code" name="code" type="text" inputmode="text" autocomplete="one-time-code" required autofocus>
 
         @error('code')
@@ -27,6 +27,6 @@
             <p class="error">{{ $message }}</p>
         @enderror
 
-        <button type="submit">Sign in</button>
+        <button type="submit">{{ __('email-magic-link::messages.sign_in') }}</button>
     </form>
 @endsection

--- a/resources/views/confirm.blade.php
+++ b/resources/views/confirm.blade.php
@@ -1,10 +1,10 @@
 @extends('email-magic-link::layout')
 
-@section('title', 'Confirm sign in')
+@section('title', __('email-magic-link::messages.confirm_title'))
 
 @section('content')
-    <h1>Sign in to {{ config('app.name') }}</h1>
-    <p>For your security, confirm that you want to sign in. This link can only be used once.</p>
+    <h1>{{ __('email-magic-link::messages.heading', ['app' => config('app.name')]) }}</h1>
+    <p>{{ __('email-magic-link::messages.confirm_intro') }}</p>
 
     @error('email')
         <p class="error">{{ $message }}</p>
@@ -12,6 +12,6 @@
 
     <form method="POST" action="{{ $action }}">
         @csrf
-        <button type="submit">Sign in</button>
+        <button type="submit">{{ __('email-magic-link::messages.sign_in') }}</button>
     </form>
 @endsection

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
-    <title>@yield('title', 'Sign in') &middot; {{ config('app.name') }}</title>
+    <title>@yield('title', __('email-magic-link::messages.sign_in')) &middot; {{ config('app.name') }}</title>
     <style>
         :root { color-scheme: light dark; }
         body {

--- a/resources/views/request.blade.php
+++ b/resources/views/request.blade.php
@@ -1,10 +1,10 @@
 @extends('email-magic-link::layout')
 
-@section('title', 'Sign in')
+@section('title', __('email-magic-link::messages.request_title'))
 
 @section('content')
-    <h1>Sign in to {{ config('app.name') }}</h1>
-    <p>Enter your email address and we will send you a secure sign-in {{ $mode === 'code' ? 'code' : 'link' }}.</p>
+    <h1>{{ __('email-magic-link::messages.heading', ['app' => config('app.name')]) }}</h1>
+    <p>{{ $mode === 'code' ? __('email-magic-link::messages.request_intro_code') : __('email-magic-link::messages.request_intro_link') }}</p>
 
     @if (session('status'))
         <div class="status" role="status">{{ session('status') }}</div>
@@ -13,7 +13,7 @@
     <form method="POST" action="{{ route('email-magic-link.request') }}">
         @csrf
 
-        <label for="email">Email address</label>
+        <label for="email">{{ __('email-magic-link::messages.email_label') }}</label>
         <input id="email" name="email" type="email" autocomplete="email" required autofocus value="{{ old('email') }}">
 
         @error('email')
@@ -22,12 +22,12 @@
 
         @if ($mode === 'both')
             <fieldset>
-                <legend>Delivery</legend>
-                <label><input type="radio" name="channel" value="link" checked> Magic link</label>
-                <label><input type="radio" name="channel" value="code"> One-time code</label>
+                <legend>{{ __('email-magic-link::messages.delivery_legend') }}</legend>
+                <label><input type="radio" name="channel" value="link" checked> {{ __('email-magic-link::messages.delivery_link') }}</label>
+                <label><input type="radio" name="channel" value="code"> {{ __('email-magic-link::messages.delivery_code') }}</label>
             </fieldset>
         @endif
 
-        <button type="submit">Send sign-in {{ $mode === 'code' ? 'code' : 'link' }}</button>
+        <button type="submit">{{ $mode === 'code' ? __('email-magic-link::messages.request_send_code') : __('email-magic-link::messages.request_send_link') }}</button>
     </form>
 @endsection

--- a/src/EmailMagicLinkServiceProvider.php
+++ b/src/EmailMagicLinkServiceProvider.php
@@ -82,6 +82,7 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
 
         $this->registerPublishing();
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'email-magic-link');
+        $this->loadTranslationsFrom(__DIR__.'/../lang', 'email-magic-link');
 
         if (self::$runsMigrations) {
             $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
@@ -180,6 +181,10 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../resources/views' => resource_path('views/vendor/email-magic-link'),
             ], 'email-magic-link-views');
+
+            $this->publishes([
+                __DIR__.'/../lang' => lang_path('vendor/email-magic-link'),
+            ], 'email-magic-link-lang');
         }
     }
 }

--- a/src/Notifications/MagicLinkNotification.php
+++ b/src/Notifications/MagicLinkNotification.php
@@ -51,20 +51,20 @@ class MagicLinkNotification extends Notification implements ShouldQueue
     private function linkMessage(string $application): MailMessage
     {
         return (new MailMessage)
-            ->subject("Sign in to {$application}")
-            ->line("Use the button below to sign in to {$application}.")
-            ->action('Sign in', (string) $this->actionUrl)
-            ->line("This link expires in {$this->expiresInMinutes} minutes and can be used once.")
-            ->line('If you did not request this, you can safely ignore this email.');
+            ->subject(__('email-magic-link::messages.mail_link_subject', ['app' => $application]))
+            ->line(__('email-magic-link::messages.mail_link_intro', ['app' => $application]))
+            ->action(__('email-magic-link::messages.mail_link_action'), (string) $this->actionUrl)
+            ->line(__('email-magic-link::messages.mail_link_expiry', ['minutes' => $this->expiresInMinutes]))
+            ->line(__('email-magic-link::messages.mail_ignore'));
     }
 
     private function codeMessage(string $application): MailMessage
     {
         return (new MailMessage)
-            ->subject("Your {$application} sign-in code")
-            ->line("Your sign-in code for {$application} is:")
+            ->subject(__('email-magic-link::messages.mail_code_subject', ['app' => $application]))
+            ->line(__('email-magic-link::messages.mail_code_intro', ['app' => $application]))
             ->line((string) $this->code)
-            ->line("This code expires in {$this->expiresInMinutes} minutes.")
-            ->line('If you did not request this, you can safely ignore this email.');
+            ->line(__('email-magic-link::messages.mail_code_expiry', ['minutes' => $this->expiresInMinutes]))
+            ->line(__('email-magic-link::messages.mail_ignore'));
     }
 }


### PR DESCRIPTION

### Added

- Translatable user-facing strings: the views and the mail notification now resolve
  every string through the `email-magic-link` translation namespace, with publishable
  language files (`--tag=email-magic-link-lang`).
