### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-06-22
+
+### Added
+
+- Optional WireKit (`pushery/wirekit`) sign-in screens. When WireKit is installed
+  the views render with its components automatically; otherwise the plain Blade
+  views are used. Controlled by the new `ui.mode` (`auto` / `blade`) and `ui.vite`
+  configuration. The routes, CSRF-protected POSTs, and single-use consumption are
+  unchanged — only the presentation differs.
+
 ## [0.3.1] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Email Magic Link for Laravel
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/pushery/email-magic-link-for-laravel.svg)](https://packagist.org/packages/pushery/email-magic-link-for-laravel)
-[![Total Downloads](https://img.shields.io/packagist/dt/pushery/email-magic-link-for-laravel.svg)](https://packagist.org/packages/pushery/email-magic-link-for-laravel)
 [![PHP Version](https://img.shields.io/packagist/php-v/pushery/email-magic-link-for-laravel.svg)](https://packagist.org/packages/pushery/email-magic-link-for-laravel)
+[![PHPStan](https://img.shields.io/badge/PHPStan-max-brightgreen.svg)](https://phpstan.org/)
+[![Code Style](https://img.shields.io/badge/code%20style-pint-orange.svg)](https://laravel.com/docs/pint)
 [![License](https://img.shields.io/packagist/l/pushery/email-magic-link-for-laravel.svg)](https://packagist.org/packages/pushery/email-magic-link-for-laravel)
 
 Passwordless email authentication for Laravel — magic links and one-time codes — that works **standalone** or alongside **Laravel Fortify**.
@@ -117,6 +118,8 @@ All values live in `config/email-magic-link.php`.
 | `routes.middleware` | `['web']` | Route middleware (sessions + CSRF). |
 | `routes.redirect_to` | `'/'` | Fallback redirect after login. |
 | `api.enabled` | `false` | Direct JSON token exchange for SPA/mobile. |
+| `ui.mode` | `'auto'` | `'auto'` (WireKit views if installed) or `'blade'`. |
+| `ui.vite` | `['resources/css/app.css']` | Vite entry the WireKit layout loads. |
 | `fortify.mode` | `'auto'` | `'auto'` (on if Fortify present), `true`, or `false`. |
 | `fortify.respect_two_factor` | `true` | Route confirmed-2FA users through the challenge. |
 | `fortify.challenge_route` | `'two-factor.login'` | Fortify challenge route name. |
@@ -153,6 +156,20 @@ php artisan vendor:publish --tag=email-magic-link-lang
 That copies the strings to `lang/vendor/email-magic-link/{locale}`. Add a locale
 by copying the `en` directory (for example to `de`) and translating the values;
 the `:app` and `:minutes` placeholders are filled in at render time.
+
+## WireKit
+
+If [WireKit](https://wirekit.app) (`pushery/wirekit`) is installed, the sign-in
+screens render with WireKit components automatically — no configuration needed.
+Without it, the package serves its own dependency-free Blade views, so it works
+either way. Set `ui.mode` to `blade` to keep the plain views even when WireKit is
+present.
+
+WireKit emits Tailwind classes and Alpine directives, so its views render inside a
+layout that loads your compiled CSS via `@vite` (configurable with `ui.vite`,
+default `resources/css/app.css`) together with `@livewireScripts` and
+`@wirekitScripts`. The flow itself is unchanged — the same signed routes,
+CSRF-protected POSTs, and single-use token consumption — only the look differs.
 
 ## Extension points
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "rector/rector": "^2.0"
     },
     "suggest": {
-        "laravel/fortify": "Enables the no-bypass two-factor (TOTP) handoff: a magic-link user with confirmed 2FA completes Fortify's challenge before being logged in (^1.0)."
+        "laravel/fortify": "Enables the no-bypass two-factor (TOTP) handoff: a magic-link user with confirmed 2FA completes Fortify's challenge before being logged in (^1.0).",
+        "pushery/wirekit": "Renders the sign-in screens with WireKit components when installed; the package auto-detects it and falls back to plain Blade otherwise."
     },
     "autoload": {
         "psr-4": {

--- a/config/email-magic-link.php
+++ b/config/email-magic-link.php
@@ -160,6 +160,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | User interface
+    |--------------------------------------------------------------------------
+    |
+    | "mode" selects the look of the bundled sign-in screens:
+    |   "auto"   render WireKit (pushery/wirekit) views when it is installed,
+    |            otherwise the plain Blade views
+    |   "blade"  always the plain Blade views, even when WireKit is installed
+    |
+    | "vite" lists the Vite entry points the WireKit layout loads, so the host's
+    | compiled Tailwind (including WireKit's styles) is present on the page.
+    |
+    */
+
+    'ui' => [
+        'mode' => env('EMAIL_MAGIC_LINK_UI', 'auto'),
+        'vite' => ['resources/css/app.css'],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Fortify bridge
     |--------------------------------------------------------------------------
     |

--- a/resources/views/wirekit/code.blade.php
+++ b/resources/views/wirekit/code.blade.php
@@ -1,0 +1,37 @@
+@extends('email-magic-link::wirekit.layout')
+
+@section('title', __('email-magic-link::messages.code_title'))
+
+@section('content')
+    <x-wirekit::card>
+        <x-wirekit::heading>{{ __('email-magic-link::messages.code_heading') }}</x-wirekit::heading>
+        <x-wirekit::text>{{ __('email-magic-link::messages.code_intro') }}</x-wirekit::text>
+
+        @if (session('status'))
+            <x-wirekit::alert variant="success">{{ session('status') }}</x-wirekit::alert>
+        @endif
+
+        <form method="POST" action="{{ route('email-magic-link.code.consume') }}">
+            @csrf
+
+            <x-wirekit::input
+                name="email"
+                type="email"
+                :label="__('email-magic-link::messages.email_label')"
+                autocomplete="email"
+                required
+                :value="$email ?: old('email')"
+                :error="$errors->first('email')"
+            />
+
+            <x-wirekit::otp-input
+                name="code"
+                :length="(int) config('email-magic-link.code_length', 8)"
+                :label="__('email-magic-link::messages.code_label')"
+                :error="$errors->first('code')"
+            />
+
+            <x-wirekit::button type="submit">{{ __('email-magic-link::messages.sign_in') }}</x-wirekit::button>
+        </form>
+    </x-wirekit::card>
+@endsection

--- a/resources/views/wirekit/confirm.blade.php
+++ b/resources/views/wirekit/confirm.blade.php
@@ -1,0 +1,19 @@
+@extends('email-magic-link::wirekit.layout')
+
+@section('title', __('email-magic-link::messages.confirm_title'))
+
+@section('content')
+    <x-wirekit::card>
+        <x-wirekit::heading>{{ __('email-magic-link::messages.heading', ['app' => config('app.name')]) }}</x-wirekit::heading>
+        <x-wirekit::text>{{ __('email-magic-link::messages.confirm_intro') }}</x-wirekit::text>
+
+        @error('email')
+            <x-wirekit::alert variant="danger">{{ $message }}</x-wirekit::alert>
+        @enderror
+
+        <form method="POST" action="{{ $action }}">
+            @csrf
+            <x-wirekit::button type="submit">{{ __('email-magic-link::messages.sign_in') }}</x-wirekit::button>
+        </form>
+    </x-wirekit::card>
+@endsection

--- a/resources/views/wirekit/layout.blade.php
+++ b/resources/views/wirekit/layout.blade.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <title>@yield('title', __('email-magic-link::messages.sign_in')) &middot; {{ config('app.name') }}</title>
+    @vite(config('email-magic-link.ui.vite', ['resources/css/app.css']))
+</head>
+<body class="min-h-screen grid place-items-center bg-neutral-50 dark:bg-neutral-950">
+    <main class="w-full max-w-sm p-8">
+        @yield('content')
+    </main>
+    @livewireScripts
+    @wirekitScripts
+</body>
+</html>

--- a/resources/views/wirekit/request.blade.php
+++ b/resources/views/wirekit/request.blade.php
@@ -1,0 +1,38 @@
+@extends('email-magic-link::wirekit.layout')
+
+@section('title', __('email-magic-link::messages.request_title'))
+
+@section('content')
+    <x-wirekit::card>
+        <x-wirekit::heading>{{ __('email-magic-link::messages.heading', ['app' => config('app.name')]) }}</x-wirekit::heading>
+        <x-wirekit::text>{{ $mode === 'code' ? __('email-magic-link::messages.request_intro_code') : __('email-magic-link::messages.request_intro_link') }}</x-wirekit::text>
+
+        @if (session('status'))
+            <x-wirekit::alert variant="success">{{ session('status') }}</x-wirekit::alert>
+        @endif
+
+        <form method="POST" action="{{ route('email-magic-link.request') }}">
+            @csrf
+
+            <x-wirekit::input
+                name="email"
+                type="email"
+                :label="__('email-magic-link::messages.email_label')"
+                autocomplete="email"
+                required
+                autofocus
+                :value="old('email')"
+                :error="$errors->first('email')"
+            />
+
+            @if ($mode === 'both')
+                <x-wirekit::radio name="channel" value="link" :label="__('email-magic-link::messages.delivery_link')" checked />
+                <x-wirekit::radio name="channel" value="code" :label="__('email-magic-link::messages.delivery_code')" />
+            @endif
+
+            <x-wirekit::button type="submit">
+                {{ $mode === 'code' ? __('email-magic-link::messages.request_send_code') : __('email-magic-link::messages.request_send_link') }}
+            </x-wirekit::button>
+        </form>
+    </x-wirekit::card>
+@endsection

--- a/src/Http/Controllers/ConfirmMagicLinkController.php
+++ b/src/Http/Controllers/ConfirmMagicLinkController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Http\Controllers;
 
+use EmailMagicLink\Support\MagicLinkConfig;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 
@@ -17,11 +18,14 @@ use Illuminate\Contracts\View\View;
  */
 final readonly class ConfirmMagicLinkController
 {
-    public function __construct(private Factory $views) {}
+    public function __construct(
+        private MagicLinkConfig $config,
+        private Factory $views,
+    ) {}
 
     public function __invoke(string $token): View
     {
-        return $this->views->make('email-magic-link::confirm', [
+        return $this->views->make($this->config->view('confirm'), [
             'token' => $token,
             'action' => route('email-magic-link.consume', ['token' => $token]),
         ]);

--- a/src/Http/Controllers/ShowCodeFormController.php
+++ b/src/Http/Controllers/ShowCodeFormController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Http\Controllers;
 
+use EmailMagicLink\Support\MagicLinkConfig;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
@@ -13,13 +14,16 @@ use Illuminate\Http\Request;
  */
 final readonly class ShowCodeFormController
 {
-    public function __construct(private Factory $views) {}
+    public function __construct(
+        private MagicLinkConfig $config,
+        private Factory $views,
+    ) {}
 
     public function __invoke(Request $request): View
     {
         $email = $request->query('email');
 
-        return $this->views->make('email-magic-link::code', [
+        return $this->views->make($this->config->view('code'), [
             'email' => is_string($email) ? $email : '',
         ]);
     }

--- a/src/Http/Controllers/ShowRequestFormController.php
+++ b/src/Http/Controllers/ShowRequestFormController.php
@@ -20,6 +20,6 @@ final readonly class ShowRequestFormController
 
     public function __invoke(): View
     {
-        return $this->views->make('email-magic-link::request', ['mode' => $this->config->mode()]);
+        return $this->views->make($this->config->view('request'), ['mode' => $this->config->mode()]);
     }
 }

--- a/src/Support/MagicLinkConfig.php
+++ b/src/Support/MagicLinkConfig.php
@@ -6,6 +6,7 @@ namespace EmailMagicLink\Support;
 
 use EmailMagicLink\Notifications\MagicLinkNotification;
 use Illuminate\Contracts\Config\Repository;
+use Illuminate\Support\Facades\View;
 
 /**
  * Typed gateway to the package configuration.
@@ -147,6 +148,35 @@ final readonly class MagicLinkConfig
     public function apiEnabled(): bool
     {
         return $this->bool($this->config->get('email-magic-link.api.enabled'), false);
+    }
+
+    /**
+     * @return 'auto'|'blade'
+     */
+    public function uiMode(): string
+    {
+        return $this->string($this->config->get('email-magic-link.ui.mode'), 'auto') === 'blade'
+            ? 'blade'
+            : 'auto';
+    }
+
+    public function usesWireKit(): bool
+    {
+        return $this->uiMode() === 'auto' && WireKit::installed();
+    }
+
+    /**
+     * Resolve a view to its WireKit variant when WireKit is active and that
+     * variant exists, else the plain Blade view. The existence check keeps the
+     * sign-in UI from breaking if a WireKit view was never published or removed.
+     */
+    public function view(string $name): string
+    {
+        $wirekit = "email-magic-link::wirekit.{$name}";
+
+        return $this->usesWireKit() && View::exists($wirekit)
+            ? $wirekit
+            : "email-magic-link::{$name}";
     }
 
     /**

--- a/src/Support/WireKit.php
+++ b/src/Support/WireKit.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+/**
+ * Detects whether WireKit (pushery/wirekit) is installed.
+ *
+ * The class name is held as a string and probed via class_exists, so the package
+ * never imports a WireKit symbol and stays loadable when WireKit is absent. Tests
+ * override the property to simulate WireKit being present.
+ */
+final class WireKit
+{
+    public static string $providerClass = 'Pushery\\WireKit\\WireKitServiceProvider';
+
+    public static function installed(): bool
+    {
+        return class_exists(self::$providerClass);
+    }
+}


### PR DESCRIPTION

### Added

- Optional WireKit (`pushery/wirekit`) sign-in screens. When WireKit is installed
  the views render with its components automatically; otherwise the plain Blade
  views are used. Controlled by the new `ui.mode` (`auto` / `blade`) and `ui.vite`
  configuration. The routes, CSRF-protected POSTs, and single-use consumption are
  unchanged — only the presentation differs.
