### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-06-22
+
+### Added
+
+- The post-login redirect now returns the user to the URL they originally requested
+  (the protected route that triggered the flow), falling back to `redirect_to`. It
+  applies to both the browser redirect and the API response, and can be turned off
+  with the new `routes.intended` config.
+
+### Changed
+
+- The API response `redirect` field is now the resolved absolute destination URL
+  (the intended URL when present, otherwise `redirect_to`).
+
 ## [0.6.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ All values live in `config/email-magic-link.php`.
 | `routes.prefix` | `''` | Route prefix. |
 | `routes.middleware` | `['web']` | Route middleware (sessions + CSRF). |
 | `routes.redirect_to` | `'/'` | Fallback redirect after login. |
+| `routes.intended` | `true` | Return to the originally requested URL after login. |
 | `api.enabled` | `false` | Direct JSON token exchange for SPA/mobile. |
 | `ui.mode` | `'auto'` | `'auto'` (WireKit views if installed) or `'blade'`. |
 | `ui.vite` | `['resources/css/app.css']` | Vite entry the WireKit layout loads. |

--- a/config/email-magic-link.php
+++ b/config/email-magic-link.php
@@ -141,6 +141,11 @@ return [
         'prefix' => '',
         'middleware' => ['web'],
         'redirect_to' => '/',
+
+        // After login, return the user to the URL they originally requested (the
+        // protected route that triggered the flow), falling back to "redirect_to"
+        // when there is none. Set false to always land on "redirect_to".
+        'intended' => true,
     ],
 
     /*

--- a/src/Authenticators/DefaultAuthenticator.php
+++ b/src/Authenticators/DefaultAuthenticator.php
@@ -47,14 +47,18 @@ final readonly class DefaultAuthenticator implements MagicLinkAuthenticator
             $request->session()->regenerate();
         }
 
+        $redirect = $this->config->redirectToIntended()
+            ? $this->redirector->intended($this->config->redirectTo())
+            : $this->redirector->to($this->config->redirectTo());
+
         if ($request->expectsJson() && $this->config->apiEnabled()) {
             return new JsonResponse([
                 'authenticated' => true,
                 'two_factor' => false,
-                'redirect' => $this->config->redirectTo(),
+                'redirect' => $redirect->getTargetUrl(),
             ]);
         }
 
-        return $this->redirector->intended($this->config->redirectTo());
+        return $redirect;
     }
 }

--- a/src/Support/MagicLinkConfig.php
+++ b/src/Support/MagicLinkConfig.php
@@ -145,6 +145,11 @@ final readonly class MagicLinkConfig
         return $this->string($this->config->get('email-magic-link.routes.redirect_to'), '/');
     }
 
+    public function redirectToIntended(): bool
+    {
+        return $this->bool($this->config->get('email-magic-link.routes.intended'), true);
+    }
+
     public function apiEnabled(): bool
     {
         return $this->bool($this->config->get('email-magic-link.api.enabled'), false);


### PR DESCRIPTION

### Added

- The post-login redirect now returns the user to the URL they originally requested
  (the protected route that triggered the flow), falling back to `redirect_to`. It
  applies to both the browser redirect and the API response, and can be turned off
  with the new `routes.intended` config.

### Changed

- The API response `redirect` field is now the resolved absolute destination URL
  (the intended URL when present, otherwise `redirect_to`).
