### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-06-22
+
+### Added
+
+- Multi-guard sign-in. A request may select a guard (from the new `guards`
+  allowlist) via a `guard` field; the token is issued for that guard, the user is
+  resolved through its provider, and login completes on it. Unknown guards fall
+  back to the default. The link and code flows are both guard-aware.
+
+### Changed
+
+- The `MagicLinkAuthenticator::authenticate()` contract gains a `string $guard`
+  argument (before `$remember`). Custom authenticators must add the parameter.
+
 ## [0.7.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ All values live in `config/email-magic-link.php`.
 | `code_alphabet` | unambiguous A–Z/2–9 | Alphabet for codes (governs keyspace). |
 | `max_attempts_per_token` | `5` | Hard per-token lockout for code mode. |
 | `entropy_safety_factor` | `1_000_000` | Guardrail bar; cannot be lowered below this floor. |
-| `guard` | app default | Stateful guard to log into. |
+| `guard` | app default | Default stateful guard to log into. |
+| `guards` | `[]` | Extra guards a request may select via a `guard` field. |
 | `user_lookup` | bundled | `UserLookup` implementation. |
 | `token_store` | bundled | `TokenStore` implementation. |
 | `notification` | `MagicLinkNotification` | Notification class (extend it to customize). |
@@ -158,6 +159,30 @@ php artisan vendor:publish --tag=email-magic-link-lang
 That copies the strings to `lang/vendor/email-magic-link/{locale}`. Add a locale
 by copying the `en` directory (for example to `de`) and translating the values;
 the `:app` and `:minutes` placeholders are filled in at render time.
+
+## Multiple guards
+
+By default everything runs through the configured `guard`. To let a request sign
+in to another guard — say an `admin` guard alongside `web` — list it in `guards`
+and submit a `guard` field from your sign-in form:
+
+```php
+'guard' => 'web',
+'guards' => ['admin'],
+```
+
+```blade
+<input type="hidden" name="guard" value="admin">
+```
+
+The request issues the token for the selected guard, the user is resolved through
+**that guard's** user provider, and login completes on it. A guard not on the
+allowlist falls back silently to the default, so guards stay un-enumerable.
+
+> Security: only list guards whose user provider you are happy to expose to
+> self-service magic-link login. A user found in a guard's provider can sign in to
+> that guard, so guards that share a provider also share access. When the Fortify
+> two-factor handoff is active, the selected guard should match `fortify.guard`.
 
 ## WireKit
 

--- a/config/email-magic-link.php
+++ b/config/email-magic-link.php
@@ -99,6 +99,13 @@ return [
 
     'guard' => env('EMAIL_MAGIC_LINK_GUARD'),
 
+    // Additional guards a request may sign in to (in addition to "guard"). A
+    // request selects one by submitting a "guard" field; anything not listed here
+    // falls back to the default guard. Only add guards whose user provider you are
+    // happy to expose to self-service magic-link login — a user found in a guard's
+    // provider can sign in to that guard.
+    'guards' => [],
+
     'user_lookup' => null,
 
     /*

--- a/resources/views/code.blade.php
+++ b/resources/views/code.blade.php
@@ -12,6 +12,9 @@
 
     <form method="POST" action="{{ route('email-magic-link.code.consume') }}">
         @csrf
+        @if ($guard ?: old('guard'))
+            <input type="hidden" name="guard" value="{{ $guard ?: old('guard') }}">
+        @endif
 
         <label for="email">{{ __('email-magic-link::messages.email_label') }}</label>
         <input id="email" name="email" type="email" autocomplete="email" required value="{{ $email ?: old('email') }}">

--- a/resources/views/wirekit/code.blade.php
+++ b/resources/views/wirekit/code.blade.php
@@ -13,6 +13,9 @@
 
         <form method="POST" action="{{ route('email-magic-link.code.consume') }}">
             @csrf
+            @if ($guard ?: old('guard'))
+                <input type="hidden" name="guard" value="{{ $guard ?: old('guard') }}">
+            @endif
 
             <x-wirekit::input
                 name="email"

--- a/src/Authenticators/DefaultAuthenticator.php
+++ b/src/Authenticators/DefaultAuthenticator.php
@@ -31,17 +31,17 @@ final readonly class DefaultAuthenticator implements MagicLinkAuthenticator
         private MagicLinkConfig $config,
     ) {}
 
-    public function authenticate(Request $request, Authenticatable $user, bool $remember): Response
+    public function authenticate(Request $request, Authenticatable $user, string $guard, bool $remember): Response
     {
-        $guard = $this->auth->guard($this->config->guard());
+        $stateful = $this->auth->guard($guard);
 
-        if (! $guard instanceof StatefulGuard) {
+        if (! $stateful instanceof StatefulGuard) {
             throw new RuntimeException(
-                "The [{$this->config->guard()}] guard is not stateful and cannot be used for magic-link login.",
+                "The [{$guard}] guard is not stateful and cannot be used for magic-link login.",
             );
         }
 
-        $guard->login($user, $remember);
+        $stateful->login($user, $remember);
 
         if ($request->hasSession()) {
             $request->session()->regenerate();

--- a/src/Authenticators/FortifyAwareAuthenticator.php
+++ b/src/Authenticators/FortifyAwareAuthenticator.php
@@ -9,6 +9,7 @@ use EmailMagicLink\Events\TwoFactorChallengeRequired;
 use EmailMagicLink\Support\MagicLinkConfig;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
+use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -32,10 +33,27 @@ final readonly class FortifyAwareAuthenticator implements MagicLinkAuthenticator
         private MagicLinkConfig $config,
     ) {}
 
-    public function authenticate(Request $request, Authenticatable $user, bool $remember): Response
+    public function authenticate(Request $request, Authenticatable $user, string $guard, bool $remember): Response
     {
         if (! $this->config->respectTwoFactor() || ! $this->hasConfirmedTwoFactor($user)) {
-            return $this->default->authenticate($request, $user, $remember);
+            return $this->default->authenticate($request, $user, $guard, $remember);
+        }
+
+        // Fortify challenges and logs in on its own guard's provider, not the
+        // token's guard. If they differ, the handoff would resolve the wrong user
+        // (or none), so fail closed rather than bypass the second factor.
+        if (! $this->config->guardSharesFortifyProvider($guard)) {
+            throw new RuntimeException(
+                "Two-factor sign-in for the [{$guard}] guard cannot complete: its user provider must match fortify.guard. Align the providers, or do not expose this guard to two-factor users.",
+            );
+        }
+
+        // The handoff stores Fortify's login.id in the session; without one it
+        // cannot complete, so fail closed rather than crash or bypass the factor.
+        if (! $request->hasSession()) {
+            throw new RuntimeException(
+                'The two-factor handoff requires a session and cannot complete for a sessionless request.',
+            );
         }
 
         // Hand off as a guest. Do not log in here: Fortify completes the login

--- a/src/Contracts/MagicLinkAuthenticator.php
+++ b/src/Contracts/MagicLinkAuthenticator.php
@@ -25,5 +25,5 @@ interface MagicLinkAuthenticator
      * response, or hand off to a second factor. They must return a response;
      * they must not rely on events to redirect.
      */
-    public function authenticate(Request $request, Authenticatable $user, bool $remember): Response;
+    public function authenticate(Request $request, Authenticatable $user, string $guard, bool $remember): Response;
 }

--- a/src/Contracts/TokenStore.php
+++ b/src/Contracts/TokenStore.php
@@ -30,10 +30,10 @@ interface TokenStore
     public function claimLink(string $token): ClaimResult;
 
     /**
-     * Atomically claim a one-time code for a known user, accounting for failed
-     * attempts and enforcing the per-token lockout.
+     * Atomically claim a one-time code for a known user on a specific guard,
+     * accounting for failed attempts and enforcing the per-token lockout.
      */
-    public function claimCode(Authenticatable $user, string $code): ClaimResult;
+    public function claimCode(Authenticatable $user, string $code, string $guard): ClaimResult;
 
     /**
      * Delete expired and consumed tokens. Returns the number removed.

--- a/src/FortifyBridgeServiceProvider.php
+++ b/src/FortifyBridgeServiceProvider.php
@@ -38,10 +38,24 @@ final class FortifyBridgeServiceProvider extends ServiceProvider
     {
         $config = $this->app->make(MagicLinkConfig::class);
 
-        if ($config->enabled() && ! $config->respectTwoFactor()) {
+        if (! $config->enabled()) {
+            return;
+        }
+
+        if (! $config->respectTwoFactor()) {
             Log::warning(
                 '[email-magic-link] fortify.respect_two_factor is disabled: magic-link logins skip the two-factor challenge for users who have it enabled.',
             );
+
+            return;
+        }
+
+        foreach ($config->allowedGuards() as $guard) {
+            if (! $config->guardSharesFortifyProvider($guard)) {
+                Log::warning(
+                    "[email-magic-link] the [{$guard}] guard's user provider differs from fortify.guard; two-factor sign-in on that guard fails closed. Align the providers or keep two-factor users on the Fortify guard.",
+                );
+            }
         }
     }
 }

--- a/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
+++ b/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
@@ -33,7 +33,7 @@ trait CompletesMagicLinkLogin
 
         event(new MagicLinkVerified($user, $request));
 
-        return app(MagicLinkAuthenticator::class)->authenticate($request, $user, false);
+        return app(MagicLinkAuthenticator::class)->authenticate($request, $user, $token->guard, false);
     }
 
     protected function resolveUser(MagicLinkToken $token): ?Authenticatable
@@ -53,6 +53,11 @@ trait CompletesMagicLinkLogin
             return response()->json(['message' => $message], 422);
         }
 
-        return redirect()->route($failureRoute)->withErrors(['email' => $message]);
+        // Flash the email and guard (never the secret code) so the code form can
+        // re-prefill them on retry without putting them in the redirect URL, which
+        // keeps the failure response shape identical and enumeration-resistant.
+        return redirect()->route($failureRoute)
+            ->withErrors(['email' => $message])
+            ->withInput($request->except('code'));
     }
 }

--- a/src/Http/Controllers/ConsumeCodeController.php
+++ b/src/Http/Controllers/ConsumeCodeController.php
@@ -31,13 +31,14 @@ final class ConsumeCodeController
         TokenStore $store,
         MagicLinkConfig $config,
     ): Response {
-        $user = $lookup->findByEmail($request->email(), $config->guard());
+        $guard = $config->resolveGuard($request->requestedGuard());
+        $user = $lookup->findByEmail($request->email(), $guard);
 
         if (! $user instanceof Authenticatable) {
             return $this->failedConsumption($request, 'email-magic-link.code.form');
         }
 
-        $result = $store->claimCode($user, $request->code());
+        $result = $store->claimCode($user, $request->code(), $guard);
         $claimed = $result->token;
 
         if (! $result->successful || ! $claimed instanceof MagicLinkToken) {

--- a/src/Http/Controllers/SendMagicLinkController.php
+++ b/src/Http/Controllers/SendMagicLinkController.php
@@ -36,7 +36,7 @@ final class SendMagicLinkController
     ): Response {
         $email = $request->email();
         $channel = $this->resolveChannel($request->requestedChannel(), $config->mode());
-        $guard = $config->guard();
+        $guard = $config->resolveGuard($request->requestedGuard());
 
         $user = $lookup->findByEmail($email, $guard);
 
@@ -49,7 +49,10 @@ final class SendMagicLinkController
             event(new MagicLinkRequested($user, $channel, $request));
         }
 
-        return $this->sentResponse($request, $channel, $email);
+        // Echo back the raw requested guard (not the resolved one) so the redirect
+        // shape is identical for allowed and unknown guards — guards stay
+        // un-enumerable. resolveGuard() re-validates it on consume.
+        return $this->sentResponse($request, $channel, $email, $request->requestedGuard());
     }
 
     /**
@@ -93,7 +96,7 @@ final class SendMagicLinkController
     /**
      * @param  'link'|'code'  $channel
      */
-    private function sentResponse(SendMagicLinkRequest $request, string $channel, string $email): Response
+    private function sentResponse(SendMagicLinkRequest $request, string $channel, string $email, ?string $guard): Response
     {
         $message = $channel === 'code'
             ? 'If an account matches that email, we have sent a sign-in code.'
@@ -104,8 +107,13 @@ final class SendMagicLinkController
         }
 
         if ($channel === 'code') {
-            return redirect()->route('email-magic-link.code.form', ['email' => $email])
-                ->with('status', $message);
+            $params = ['email' => $email];
+
+            if ($guard !== null) {
+                $params['guard'] = $guard;
+            }
+
+            return redirect()->route('email-magic-link.code.form', $params)->with('status', $message);
         }
 
         return redirect()->route('email-magic-link.request.form')->with('status', $message);

--- a/src/Http/Controllers/ShowCodeFormController.php
+++ b/src/Http/Controllers/ShowCodeFormController.php
@@ -22,9 +22,11 @@ final readonly class ShowCodeFormController
     public function __invoke(Request $request): View
     {
         $email = $request->query('email');
+        $guard = $request->query('guard');
 
         return $this->views->make($this->config->view('code'), [
             'email' => is_string($email) ? $email : '',
+            'guard' => is_string($guard) ? $guard : '',
         ]);
     }
 }

--- a/src/Http/Requests/ConsumeCodeRequest.php
+++ b/src/Http/Requests/ConsumeCodeRequest.php
@@ -29,6 +29,7 @@ final class ConsumeCodeRequest extends FormRequest
         return [
             'email' => ['required', 'string', 'email', 'max:255'],
             'code' => ['required', 'string', 'max:255'],
+            'guard' => ['sometimes', 'nullable', 'string', 'max:255'],
         ];
     }
 
@@ -56,5 +57,12 @@ final class ConsumeCodeRequest extends FormRequest
         $code = $this->validated('code');
 
         return is_string($code) ? $code : '';
+    }
+
+    public function requestedGuard(): ?string
+    {
+        $guard = $this->validated('guard');
+
+        return is_string($guard) && $guard !== '' ? $guard : null;
     }
 }

--- a/src/Http/Requests/SendMagicLinkRequest.php
+++ b/src/Http/Requests/SendMagicLinkRequest.php
@@ -29,6 +29,9 @@ final class SendMagicLinkRequest extends FormRequest
         return [
             'email' => ['required', 'string', 'email', 'max:255'],
             'channel' => ['sometimes', 'nullable', 'string', Rule::in(['link', 'code'])],
+            // Not validated against the allowlist here: an unknown guard falls back
+            // to the default in the controller, which keeps guards un-enumerable.
+            'guard' => ['sometimes', 'nullable', 'string', 'max:255'],
         ];
     }
 
@@ -54,5 +57,12 @@ final class SendMagicLinkRequest extends FormRequest
         $channel = $this->validated('channel');
 
         return is_string($channel) && $channel !== '' ? $channel : null;
+    }
+
+    public function requestedGuard(): ?string
+    {
+        $guard = $this->validated('guard');
+
+        return is_string($guard) && $guard !== '' ? $guard : null;
     }
 }

--- a/src/Stores/DefaultTokenStore.php
+++ b/src/Stores/DefaultTokenStore.php
@@ -36,10 +36,12 @@ final readonly class DefaultTokenStore implements TokenStore
         $userId = $this->identifierOf($user);
 
         if ($channel === 'code') {
-            // Keep at most one active code per user so a claim is unambiguous.
+            // Keep at most one active code per user PER GUARD so a claim is
+            // unambiguous and issuing for one guard never clobbers another's code.
             MagicLinkToken::query()
                 ->where('user_id', $userId)
                 ->where('channel', 'code')
+                ->where('guard', $guard)
                 ->whereNull('consumed_at')
                 ->update(['consumed_at' => $now]);
         }
@@ -78,45 +80,53 @@ final readonly class DefaultTokenStore implements TokenStore
         return ClaimResult::failed($this->classifyLinkFailure($hash, $now));
     }
 
-    public function claimCode(Authenticatable $user, string $code): ClaimResult
+    public function claimCode(Authenticatable $user, string $code, string $guard): ClaimResult
     {
-        $now = Carbon::now();
-        $max = $this->config->maxAttemptsPerToken();
+        // The whole read-check-claim runs under a row lock so the attempt gate is
+        // evaluated against fresh state: concurrent guesses cannot each pass a
+        // stale attempts < max snapshot. The guard filter binds the token to the
+        // guard the request is authenticating against, so a code issued for one
+        // guard can never be claimed through another even if their providers
+        // share a user identifier.
+        return $this->connection()->transaction(function () use ($user, $code, $guard): ClaimResult {
+            $now = Carbon::now();
+            $max = $this->config->maxAttemptsPerToken();
 
-        $token = MagicLinkToken::query()
-            ->where('user_id', $this->identifierOf($user))
-            ->where('channel', 'code')
-            ->whereNull('consumed_at')
-            ->orderByDesc('id')
-            ->first();
+            $token = MagicLinkToken::query()
+                ->where('user_id', $this->identifierOf($user))
+                ->where('channel', 'code')
+                ->where('guard', $guard)
+                ->whereNull('consumed_at')
+                ->orderByDesc('id')
+                ->lockForUpdate()
+                ->first();
 
-        if ($token === null) {
-            return ClaimResult::failed(ClaimFailure::NotFound);
-        }
+            if ($token === null) {
+                return ClaimResult::failed(ClaimFailure::NotFound);
+            }
 
-        if ($token->isExpired($now)) {
-            return ClaimResult::failed(ClaimFailure::Expired);
-        }
+            if ($token->isExpired($now)) {
+                return ClaimResult::failed(ClaimFailure::Expired);
+            }
 
-        if ($token->attempts >= $max) {
-            return ClaimResult::failed(ClaimFailure::LockedOut);
-        }
+            if ($token->attempts >= $max) {
+                return ClaimResult::failed(ClaimFailure::LockedOut);
+            }
 
-        if (! $this->hasher->matches($code, $token->token_hash)) {
-            return $this->recordFailedCodeAttempt($token, $max, $now);
-        }
+            if (! $this->hasher->matches($code, $token->token_hash)) {
+                return $this->recordFailedCodeAttempt($token, $max, $now);
+            }
 
-        if (! $this->atomicClaim('id', (string) $token->id, 'code', $now)) {
-            // Only reachable when a concurrent request consumes this same token
-            // between the lookup above and this claim. The single conditional
-            // UPDATE in atomicClaim() is what makes that race safe; this branch
-            // just maps the losing request's outcome.
-            return ClaimResult::failed(ClaimFailure::AlreadyConsumed); // @codeCoverageIgnore
-        }
+            if (! $this->atomicClaim('id', (string) $token->id, 'code', $now)) {
+                // Unreachable once the row lock above serialises claims; kept as a
+                // defensive backstop that maps a losing race to a clean outcome.
+                return ClaimResult::failed(ClaimFailure::AlreadyConsumed); // @codeCoverageIgnore
+            }
 
-        $token->consumed_at = $now;
+            $token->consumed_at = $now;
 
-        return ClaimResult::success($token);
+            return ClaimResult::success($token);
+        });
     }
 
     public function purge(): int

--- a/src/Support/MagicLinkConfig.php
+++ b/src/Support/MagicLinkConfig.php
@@ -85,6 +85,40 @@ final readonly class MagicLinkConfig
         return $this->string($this->config->get('auth.defaults.guard'), 'web');
     }
 
+    /**
+     * The guards a request may sign in to: the default plus any in "guards".
+     *
+     * @return list<string>
+     */
+    public function allowedGuards(): array
+    {
+        $list = [$this->guard()];
+
+        $guards = $this->config->get('email-magic-link.guards');
+
+        if (is_array($guards)) {
+            foreach ($guards as $guard) {
+                if (is_string($guard) && $guard !== '' && ! in_array($guard, $list, true)) {
+                    $list[] = $guard;
+                }
+            }
+        }
+
+        return $list;
+    }
+
+    /**
+     * Resolve the guard for a request: the requested one when it is on the
+     * allowlist, otherwise the default. An unknown guard falls back silently so
+     * the request endpoint stays enumeration-resistant.
+     */
+    public function resolveGuard(?string $requested): string
+    {
+        return $requested !== null && in_array($requested, $this->allowedGuards(), true)
+            ? $requested
+            : $this->guard();
+    }
+
     public function userLookup(): ?string
     {
         $lookup = $this->config->get('email-magic-link.user_lookup');
@@ -212,6 +246,27 @@ final readonly class MagicLinkConfig
         return $this->string($this->config->get('email-magic-link.fortify.challenge_route'), 'two-factor.login');
     }
 
+    /**
+     * Whether a guard's user provider matches Fortify's guard provider.
+     *
+     * The two-factor handoff completes inside Fortify, which always challenges
+     * and logs in on its own guard's provider. A guard whose provider differs
+     * therefore cannot carry a two-factor user through the challenge.
+     */
+    public function guardSharesFortifyProvider(string $guard): bool
+    {
+        $fortifyGuard = $this->string($this->config->get('fortify.guard'), '');
+
+        if ($fortifyGuard === '') {
+            $fortifyGuard = $this->string($this->config->get('auth.defaults.guard'), 'web');
+        }
+
+        $guardProvider = $this->config->get("auth.guards.{$guard}.provider");
+        $fortifyProvider = $this->config->get("auth.guards.{$fortifyGuard}.provider");
+
+        return is_string($guardProvider) && is_string($fortifyProvider) && $guardProvider === $fortifyProvider;
+    }
+
     public function requestLimiter(): string
     {
         return $this->string($this->config->get('email-magic-link.limiters.request'), 'email-magic-link:request');
@@ -247,7 +302,7 @@ final readonly class MagicLinkConfig
         $limit = is_array($limit) ? $limit : [];
 
         return [
-            'max' => $this->int($limit['max'] ?? null, $defaultMax),
+            'max' => max(1, $this->int($limit['max'] ?? null, $defaultMax)),
             'per_minutes' => max(1, $this->int($limit['per_minutes'] ?? null, 1)),
         ];
     }

--- a/src/Support/RateLimits.php
+++ b/src/Support/RateLimits.php
@@ -24,7 +24,7 @@ final readonly class RateLimits
     {
         $limit = $this->config->requestLimit();
         $email = $request->input('email');
-        $email = is_string($email) ? mb_strtolower($email) : '';
+        $email = is_string($email) ? mb_strtolower(trim($email)) : '';
 
         return [
             Limit::perMinutes($limit['per_minutes'], $limit['max'])->by('eml:req:email:'.$email),
@@ -43,7 +43,7 @@ final readonly class RateLimits
 
         $discriminator = is_string($token) && $token !== ''
             ? hash('sha256', $token)
-            : (is_string($email) ? mb_strtolower($email) : '');
+            : (is_string($email) ? mb_strtolower(trim($email)) : '');
 
         return [
             Limit::perMinutes($limit['per_minutes'], $limit['max'])->by('eml:con:ip:'.($request->ip())),


### PR DESCRIPTION

### Added

- Multi-guard sign-in. A request may select a guard (from the new `guards`
  allowlist) via a `guard` field; the token is issued for that guard, the user is
  resolved through its provider, and login completes on it. Unknown guards fall
  back to the default. The link and code flows are both guard-aware.

### Changed

- The `MagicLinkAuthenticator::authenticate()` contract gains a `string $guard`
  argument (before `$remember`). Custom authenticators must add the parameter.
