### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-06-22
+
+### Added
+
+- `MagicLinkAuthenticated($user, $guard, $request)` event, fired the moment a user
+  is actually logged in (never for a two-factor hand-off) — the precise signal for
+  an audit log, carrying the guard.
+- `MagicLinkConsumptionFailed($reason, $request)` event, fired on every failed
+  consume. The `ClaimFailure` reason distinguishes a stale or unknown token from a
+  wrong code or a brute-force `LockedOut`, so a host can log all failures and alert
+  on lockouts without the user-facing response ever leaking the reason.
+
 ## [0.8.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -212,11 +212,13 @@ The contract returns a response, so it — not an event — is where login-versu
 
 **React to events** (observability only — they must not drive flow control):
 
-- `MagicLinkRequested($user, $channel, $request)`
-- `MagicLinkVerified($user, $request)`
-- `TwoFactorChallengeRequired($user, $request)` (fired by the bridge)
+- `MagicLinkRequested($user, $channel, $request)` — a link or code was issued for a known user.
+- `MagicLinkVerified($user, $request)` — a token was verified and consumed, before the authenticator runs.
+- `MagicLinkAuthenticated($user, $guard, $request)` — the user was actually logged in (fires only on a completed login, never for a two-factor hand-off), the precise signal for an audit log.
+- `MagicLinkConsumptionFailed($reason, $request)` — a consume attempt failed; `$reason` is a `ClaimFailure` (`NotFound`, `Expired`, `InvalidCode`, `LockedOut`, `AlreadyConsumed`), so you can log every failure and alert specifically on `LockedOut` (a brute-force lockout) or repeated `InvalidCode`.
+- `TwoFactorChallengeRequired($user, $request)` (fired by the bridge) — a confirmed-2FA user is being handed to the challenge.
 
-Successful logins also fire Laravel's own `Illuminate\Auth\Events\Login`.
+Each carries the `Request`, so a listener can record the IP and user agent. The response stays generic and enumeration-resistant regardless of which failure reason fired. Successful logins also fire Laravel's own `Illuminate\Auth\Events\Login`.
 
 **Swap collaborators** via config: the `notification` class (extend `MagicLinkNotification`), a `UserLookup` (resolve users your way), and a `TokenStore` (custom persistence).
 

--- a/src/Authenticators/DefaultAuthenticator.php
+++ b/src/Authenticators/DefaultAuthenticator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EmailMagicLink\Authenticators;
 
 use EmailMagicLink\Contracts\MagicLinkAuthenticator;
+use EmailMagicLink\Events\MagicLinkAuthenticated;
 use EmailMagicLink\Support\MagicLinkConfig;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -46,6 +47,8 @@ final readonly class DefaultAuthenticator implements MagicLinkAuthenticator
         if ($request->hasSession()) {
             $request->session()->regenerate();
         }
+
+        event(new MagicLinkAuthenticated($user, $guard, $request));
 
         $redirect = $this->config->redirectToIntended()
             ? $this->redirector->intended($this->config->redirectTo())

--- a/src/Events/MagicLinkAuthenticated.php
+++ b/src/Events/MagicLinkAuthenticated.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Events;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
+
+/**
+ * Fired the moment a user is actually logged in via a magic link or code.
+ *
+ * Unlike MagicLinkVerified (which fires for every verified token, including one
+ * being handed off to a two-factor challenge), this fires only after the login
+ * has completed on the guard — the precise signal an audit log wants. The guard
+ * the user was signed in to, and the request (for IP and user agent), are
+ * carried for logging and alerting.
+ */
+final readonly class MagicLinkAuthenticated
+{
+    public function __construct(
+        public Authenticatable $user,
+        public string $guard,
+        public Request $request,
+    ) {}
+}

--- a/src/Events/MagicLinkConsumptionFailed.php
+++ b/src/Events/MagicLinkConsumptionFailed.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Events;
+
+use EmailMagicLink\Support\ClaimFailure;
+use Illuminate\Http\Request;
+
+/**
+ * Fired when a magic link or code consumption fails.
+ *
+ * The reason distinguishes a stale or unknown token from a wrong code or a
+ * brute-force lockout (ClaimFailure::LockedOut), so a host can log every failure
+ * and alert specifically on repeated invalid codes or lockouts. The response the
+ * caller sees stays generic and enumeration-resistant regardless of the reason.
+ */
+final readonly class MagicLinkConsumptionFailed
+{
+    public function __construct(
+        public ClaimFailure $reason,
+        public Request $request,
+    ) {}
+}

--- a/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
+++ b/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace EmailMagicLink\Http\Controllers\Concerns;
 
 use EmailMagicLink\Contracts\MagicLinkAuthenticator;
+use EmailMagicLink\Events\MagicLinkConsumptionFailed;
 use EmailMagicLink\Events\MagicLinkVerified;
 use EmailMagicLink\Models\MagicLinkToken;
+use EmailMagicLink\Support\ClaimFailure;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
@@ -28,7 +30,7 @@ trait CompletesMagicLinkLogin
         $user = $this->resolveUser($token);
 
         if ($user === null) {
-            return $this->failedConsumption($request, $failureRoute);
+            return $this->failedConsumption($request, $failureRoute, ClaimFailure::NotFound);
         }
 
         event(new MagicLinkVerified($user, $request));
@@ -45,8 +47,10 @@ trait CompletesMagicLinkLogin
             ?->retrieveById($token->user_id);
     }
 
-    protected function failedConsumption(Request $request, string $failureRoute): Response
+    protected function failedConsumption(Request $request, string $failureRoute, ClaimFailure $reason): Response
     {
+        event(new MagicLinkConsumptionFailed($reason, $request));
+
         $message = 'This sign-in request is invalid or has expired. Please request a new one.';
 
         if ($this->wantsJson($request)) {

--- a/src/Http/Controllers/ConsumeCodeController.php
+++ b/src/Http/Controllers/ConsumeCodeController.php
@@ -9,6 +9,7 @@ use EmailMagicLink\Contracts\UserLookup;
 use EmailMagicLink\Http\Controllers\Concerns\CompletesMagicLinkLogin;
 use EmailMagicLink\Http\Requests\ConsumeCodeRequest;
 use EmailMagicLink\Models\MagicLinkToken;
+use EmailMagicLink\Support\ClaimFailure;
 use EmailMagicLink\Support\MagicLinkConfig;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Symfony\Component\HttpFoundation\Response;
@@ -35,14 +36,14 @@ final class ConsumeCodeController
         $user = $lookup->findByEmail($request->email(), $guard);
 
         if (! $user instanceof Authenticatable) {
-            return $this->failedConsumption($request, 'email-magic-link.code.form');
+            return $this->failedConsumption($request, 'email-magic-link.code.form', ClaimFailure::NotFound);
         }
 
         $result = $store->claimCode($user, $request->code(), $guard);
         $claimed = $result->token;
 
         if (! $result->successful || ! $claimed instanceof MagicLinkToken) {
-            return $this->failedConsumption($request, 'email-magic-link.code.form');
+            return $this->failedConsumption($request, 'email-magic-link.code.form', $result->failure ?? ClaimFailure::NotFound);
         }
 
         return $this->completeLogin($request, $claimed, 'email-magic-link.code.form');

--- a/src/Http/Controllers/ConsumeMagicLinkController.php
+++ b/src/Http/Controllers/ConsumeMagicLinkController.php
@@ -7,6 +7,7 @@ namespace EmailMagicLink\Http\Controllers;
 use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Http\Controllers\Concerns\CompletesMagicLinkLogin;
 use EmailMagicLink\Models\MagicLinkToken;
+use EmailMagicLink\Support\ClaimFailure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -26,7 +27,7 @@ final class ConsumeMagicLinkController
         $claimed = $result->token;
 
         if (! $result->successful || ! $claimed instanceof MagicLinkToken) {
-            return $this->failedConsumption($request, 'email-magic-link.request.form');
+            return $this->failedConsumption($request, 'email-magic-link.request.form', $result->failure ?? ClaimFailure::NotFound);
         }
 
         return $this->completeLogin($request, $claimed, 'email-magic-link.request.form');


### PR DESCRIPTION

### Added

- `MagicLinkAuthenticated($user, $guard, $request)` event, fired the moment a user
  is actually logged in (never for a two-factor hand-off) — the precise signal for
  an audit log, carrying the guard.
- `MagicLinkConsumptionFailed($reason, $request)` event, fired on every failed
  consume. The `ClaimFailure` reason distinguishes a stale or unknown token from a
  wrong code or a brute-force `LockedOut`, so a host can log all failures and alert
  on lockouts without the user-facing response ever leaking the reason.
