### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-06-22
+
+### Added
+
+- A stable JSON error envelope for the API variant: failed consumptions now return
+  `{ "message": …, "error": "invalid_or_expired" }`, a machine-readable code a SPA
+  or mobile client can branch on without parsing the human message.
+- The two-factor hand-off now answers an API client with
+  `{ "authenticated": false, "two_factor": true, "redirect": … }` instead of a bare
+  redirect, so the client knows it must complete the challenge and where to go.
+
+### Changed
+
+- Documented the full JSON token-exchange contract (success, two-factor, error,
+  validation, and rate-limit shapes) in the README.
+
 ## [0.9.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,7 +81,18 @@ The channel itself can be turned off completely with `enabled = false`, independ
 
 Because consumption is `POST`-only, the user clicks the emailed link (a `GET`) and then clicks "Sign in" on the confirmation page. That second click is the price of being safe against link-following security scanners and prefetch — tools that would otherwise spend a single-use token before the person ever sees it. We consider that trade-off worth it; it is the whole point of the package.
 
-For first-party SPA or mobile clients that exchange the token over JSON without an interstitial, set `api.enabled = true` and `POST` the token with an `Accept: application/json` header.
+For first-party SPA or mobile clients that exchange the token over JSON without an interstitial, set `api.enabled = true` and send `Accept: application/json`. The endpoints then speak a stable JSON contract:
+
+| Outcome | Status | Body |
+| --- | --- | --- |
+| Link / code requested | `200` | `{ "message": "…", "channel": "link"\|"code" }` |
+| Signed in | `200` | `{ "authenticated": true, "two_factor": false, "redirect": "<url>" }` |
+| Two-factor required | `200` | `{ "authenticated": false, "two_factor": true, "redirect": "<challenge url>" }` |
+| Invalid or expired | `422` | `{ "message": "…", "error": "invalid_or_expired" }` |
+| Validation failed | `422` | `{ "message": "…", "errors": { … } }` |
+| Rate limited | `429` | `{ "message": "…" }` + `Retry-After` / `X-RateLimit-*` headers |
+
+The `error` code is stable and safe to branch on, while the human `message` stays generic so it never reveals whether an account exists. A `two_factor` response means the client must send the user to `redirect` to finish the TOTP challenge — the second factor is never skipped.
 
 ## The two-factor handoff (and its trade-off)
 

--- a/src/Authenticators/FortifyAwareAuthenticator.php
+++ b/src/Authenticators/FortifyAwareAuthenticator.php
@@ -8,6 +8,7 @@ use EmailMagicLink\Contracts\MagicLinkAuthenticator;
 use EmailMagicLink\Events\TwoFactorChallengeRequired;
 use EmailMagicLink\Support\MagicLinkConfig;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
@@ -65,7 +66,19 @@ final readonly class FortifyAwareAuthenticator implements MagicLinkAuthenticator
 
         event(new TwoFactorChallengeRequired($user, $request));
 
-        return redirect()->route($this->config->challengeRoute());
+        $redirect = redirect()->route($this->config->challengeRoute());
+
+        // Tell an API client it must complete the second factor and where to go,
+        // rather than handing it a bare redirect it cannot follow.
+        if ($request->expectsJson() && $this->config->apiEnabled()) {
+            return new JsonResponse([
+                'authenticated' => false,
+                'two_factor' => true,
+                'redirect' => $redirect->getTargetUrl(),
+            ]);
+        }
+
+        return $redirect;
     }
 
     private function hasConfirmedTwoFactor(Authenticatable $user): bool

--- a/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
+++ b/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
@@ -54,7 +54,7 @@ trait CompletesMagicLinkLogin
         $message = 'This sign-in request is invalid or has expired. Please request a new one.';
 
         if ($this->wantsJson($request)) {
-            return response()->json(['message' => $message], 422);
+            return $this->apiError($message, 'invalid_or_expired', 422);
         }
 
         // Flash the email and guard (never the secret code) so the code form can

--- a/src/Http/Controllers/Concerns/RespondsToApiClients.php
+++ b/src/Http/Controllers/Concerns/RespondsToApiClients.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EmailMagicLink\Http\Controllers\Concerns;
 
 use EmailMagicLink\Support\MagicLinkConfig;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 /**
@@ -19,5 +20,14 @@ trait RespondsToApiClients
     protected function wantsJson(Request $request): bool
     {
         return $request->expectsJson() && app(MagicLinkConfig::class)->apiEnabled();
+    }
+
+    /**
+     * Build the standard JSON error envelope: a human `message` and a stable,
+     * machine-readable `error` code a client can branch on without parsing prose.
+     */
+    protected function apiError(string $message, string $error, int $status): JsonResponse
+    {
+        return new JsonResponse(['message' => $message, 'error' => $error], $status);
     }
 }


### PR DESCRIPTION

### Added

- A stable JSON error envelope for the API variant: failed consumptions now return
  `{ "message": …, "error": "invalid_or_expired" }`, a machine-readable code a SPA
  or mobile client can branch on without parsing the human message.
- The two-factor hand-off now answers an API client with
  `{ "authenticated": false, "two_factor": true, "redirect": … }` instead of a bare
  redirect, so the client knows it must complete the challenge and where to go.

### Changed

- Documented the full JSON token-exchange contract (success, two-factor, error,
  validation, and rate-limit shapes) in the README.
