### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-06-22
+
+### Added
+
+- A `CaptchaGuard` extension point. Point the new `captcha` config at a class
+  implementing `EmailMagicLink\Contracts\CaptchaGuard` to verify a CAPTCHA
+  (hCaptcha, Turnstile, reCAPTCHA) or any pre-issue challenge before a link or code
+  is issued. It runs before the user lookup, so a failed challenge rejects the
+  request identically whether or not the account exists, and returns a
+  `captcha_failed` error (JSON) or a form error. The default applies no challenge.
+
 ## [0.10.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -231,13 +231,31 @@ The contract returns a response, so it — not an event — is where login-versu
 
 Each carries the `Request`, so a listener can record the IP and user agent. The response stays generic and enumeration-resistant regardless of which failure reason fired. Successful logins also fire Laravel's own `Illuminate\Auth\Events\Login`.
 
-**Swap collaborators** via config: the `notification` class (extend `MagicLinkNotification`), a `UserLookup` (resolve users your way), and a `TokenStore` (custom persistence).
+**Swap collaborators** via config: the `notification` class (extend `MagicLinkNotification`), a `UserLookup` (resolve users your way), a `TokenStore` (custom persistence), and a `CaptchaGuard` (a pre-issue challenge).
+
+**Gate requests with a CAPTCHA.** Point the `captcha` config at a class implementing `EmailMagicLink\Contracts\CaptchaGuard`:
+
+```php
+final class TurnstileGuard implements CaptchaGuard
+{
+    public function passes(Request $request): bool
+    {
+        // Verify the challenge token (e.g. cf-turnstile-response) with the provider.
+        return Http::asForm()->post('https://challenges.cloudflare.com/turnstile/v0/siteverify', [
+            'secret' => config('services.turnstile.secret'),
+            'response' => $request->input('cf-turnstile-response'),
+        ])->json('success') === true;
+    }
+}
+```
+
+It runs before any user lookup, so a failed challenge rejects the request identically whether or not the email exists — it can never become an enumeration oracle. A failure returns the `captcha_failed` JSON error (or a form error) and issues nothing.
 
 ## Security at rest
 
 Tokens are never stored in the clear — only a keyed HMAC-SHA256 hash, looked up via an index. Consumption is a single race-free conditional claim (PostgreSQL `RETURNING`, with a portable affected-rows fallback) so two concurrent requests can never both succeed. Links are additionally protected by Laravel signed routes. Raw tokens and full link URLs are never logged.
 
-The request endpoint is rate-limited per email and per IP out of the box. For high-risk deployments, layer a CAPTCHA or challenge widget on the request form as an additional bot-protection measure — that is a host-application concern this package deliberately leaves to you. Throttled responses carry the standard `Retry-After` and `X-RateLimit-*` headers, so API and SPA clients can back off correctly.
+The request endpoint is rate-limited per email and per IP out of the box. For high-risk deployments, layer a CAPTCHA or challenge widget on top via the `captcha` guard (see [Extension points](#extension-points)) as an additional bot-protection measure. Throttled responses carry the standard `Retry-After` and `X-RateLimit-*` headers, so API and SPA clients can back off correctly.
 
 See [SECURITY.md](SECURITY.md) for the supported versions and how to report a vulnerability.
 

--- a/config/email-magic-link.php
+++ b/config/email-magic-link.php
@@ -123,6 +123,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Captcha guard
+    |--------------------------------------------------------------------------
+    |
+    | A class implementing the CaptchaGuard contract, run before a link or code
+    | is issued. Use it to verify a CAPTCHA (hCaptcha, Turnstile, reCAPTCHA) or
+    | any pre-issue challenge. It sees only the request, never the account, so it
+    | cannot leak whether an email exists. Leave null to apply no challenge.
+    |
+    */
+
+    'captcha' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Notification
     |--------------------------------------------------------------------------
     |

--- a/src/Captcha/NullCaptchaGuard.php
+++ b/src/Captcha/NullCaptchaGuard.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Captcha;
+
+use EmailMagicLink\Contracts\CaptchaGuard;
+use Illuminate\Http\Request;
+
+/**
+ * The default guard: no challenge, every request passes.
+ *
+ * Bind your own CaptchaGuard via the `captcha` config to verify hCaptcha,
+ * Cloudflare Turnstile, reCAPTCHA, or any pre-issue challenge before a link or
+ * code is sent.
+ */
+final class NullCaptchaGuard implements CaptchaGuard
+{
+    public function passes(Request $request): bool
+    {
+        return true;
+    }
+}

--- a/src/Contracts/CaptchaGuard.php
+++ b/src/Contracts/CaptchaGuard.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Contracts;
+
+use Illuminate\Http\Request;
+
+/**
+ * Decides whether a request may proceed to issue a link or code.
+ *
+ * Runs before any user lookup, so an implementation must depend only on the
+ * request itself — a CAPTCHA token, a challenge header, a custom rule — and never
+ * on whether an account exists, which would turn it into an enumeration oracle.
+ */
+interface CaptchaGuard
+{
+    public function passes(Request $request): bool;
+}

--- a/src/EmailMagicLinkServiceProvider.php
+++ b/src/EmailMagicLinkServiceProvider.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace EmailMagicLink;
 
 use EmailMagicLink\Authenticators\DefaultAuthenticator;
+use EmailMagicLink\Captcha\NullCaptchaGuard;
 use EmailMagicLink\Console\Commands\InstallCommand;
 use EmailMagicLink\Console\Commands\PurgeExpiredTokensCommand;
+use EmailMagicLink\Contracts\CaptchaGuard;
 use EmailMagicLink\Contracts\MagicLinkAuthenticator;
 use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Contracts\UserLookup;
@@ -71,6 +73,12 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
             $custom = $app->make(MagicLinkConfig::class)->userLookup();
 
             return $this->resolveContract($app, UserLookup::class, $custom, DefaultUserLookup::class);
+        });
+
+        $this->app->singleton(CaptchaGuard::class, function (Application $app): CaptchaGuard {
+            $custom = $app->make(MagicLinkConfig::class)->captcha();
+
+            return $this->resolveContract($app, CaptchaGuard::class, $custom, NullCaptchaGuard::class);
         });
 
         $this->app->singleton(MagicLinkAuthenticator::class, DefaultAuthenticator::class);

--- a/src/Http/Controllers/SendMagicLinkController.php
+++ b/src/Http/Controllers/SendMagicLinkController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Http\Controllers;
 
+use EmailMagicLink\Contracts\CaptchaGuard;
 use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Contracts\UserLookup;
 use EmailMagicLink\Events\MagicLinkRequested;
@@ -33,7 +34,14 @@ final class SendMagicLinkController
         UserLookup $lookup,
         TokenStore $store,
         MagicLinkConfig $config,
+        CaptchaGuard $captcha,
     ): Response {
+        // Pre-issue challenge, before any user lookup, so it gates the request
+        // without ever depending on whether the account exists.
+        if (! $captcha->passes($request)) {
+            return $this->captchaFailed($request);
+        }
+
         $email = $request->email();
         $channel = $this->resolveChannel($request->requestedChannel(), $config->mode());
         $guard = $config->resolveGuard($request->requestedGuard());
@@ -53,6 +61,19 @@ final class SendMagicLinkController
         // shape is identical for allowed and unknown guards — guards stay
         // un-enumerable. resolveGuard() re-validates it on consume.
         return $this->sentResponse($request, $channel, $email, $request->requestedGuard());
+    }
+
+    private function captchaFailed(SendMagicLinkRequest $request): Response
+    {
+        $message = 'The verification challenge failed. Please try again.';
+
+        if ($this->wantsJson($request)) {
+            return $this->apiError($message, 'captcha_failed', 422);
+        }
+
+        return redirect()->route('email-magic-link.request.form')
+            ->withErrors(['email' => $message])
+            ->withInput($request->only('email'));
     }
 
     /**

--- a/src/Support/MagicLinkConfig.php
+++ b/src/Support/MagicLinkConfig.php
@@ -133,6 +133,13 @@ final readonly class MagicLinkConfig
         return is_string($store) && $store !== '' ? $store : null;
     }
 
+    public function captcha(): ?string
+    {
+        $captcha = $this->config->get('email-magic-link.captcha');
+
+        return is_string($captcha) && $captcha !== '' ? $captcha : null;
+    }
+
     /**
      * @return class-string<MagicLinkNotification>
      */


### PR DESCRIPTION

### Added

- A `CaptchaGuard` extension point. Point the new `captcha` config at a class
  implementing `EmailMagicLink\Contracts\CaptchaGuard` to verify a CAPTCHA
  (hCaptcha, Turnstile, reCAPTCHA) or any pre-issue challenge before a link or code
  is issued. It runs before the user lookup, so a failed challenge rejects the
  request identically whether or not the account exists, and returns a
  `captcha_failed` error (JSON) or a form error. The default applies no challenge.
