### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-06-22
+
+### Added
+
+- Per-channel token lifetimes. The new `link_ttl` and `code_ttl` config keys give
+  links and codes their own expiry — for example a shorter, hand-typed code — while
+  `ttl` remains the default both inherit when an override is unset or non-positive.
+  The notification's "expires in N minutes" line and the link's signed-route expiry
+  follow the channel's lifetime.
+
 ## [0.11.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ All values live in `config/email-magic-link.php`.
 |---|---|---|
 | `enabled` | `true` | Master switch for the channel (routes, notifications, limiters). |
 | `mode` | `'link'` | `'link'`, `'code'`, or `'both'`. |
-| `ttl` | `900` | Token lifetime in seconds. |
+| `ttl` | `900` | Default token lifetime in seconds. |
+| `link_ttl` | `null` | Link lifetime in seconds; inherits `ttl` when unset. |
+| `code_ttl` | `null` | Code lifetime in seconds; inherits `ttl` when unset (handy for a shorter, hand-typed code). |
 | `code_length` | `8` | One-time code length. |
 | `code_alphabet` | unambiguous A–Z/2–9 | Alphabet for codes (governs keyspace). |
 | `max_attempts_per_token` | `5` | Hard per-token lockout for code mode. |

--- a/config/email-magic-link.php
+++ b/config/email-magic-link.php
@@ -40,11 +40,18 @@ return [
     |--------------------------------------------------------------------------
     |
     | How long an issued link or code stays valid. Expired tokens are rejected
-    | regardless of whether they were ever consumed.
+    | regardless of whether they were ever consumed. "ttl" is the default for
+    | both channels; set "link_ttl" or "code_ttl" to a positive number of seconds
+    | to give a channel its own lifetime (for example a shorter code that is typed
+    | by hand). A null or non-positive override inherits "ttl".
     |
     */
 
     'ttl' => (int) env('EMAIL_MAGIC_LINK_TTL', 900),
+
+    'link_ttl' => env('EMAIL_MAGIC_LINK_LINK_TTL'),
+
+    'code_ttl' => env('EMAIL_MAGIC_LINK_CODE_TTL'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Http/Controllers/SendMagicLinkController.php
+++ b/src/Http/Controllers/SendMagicLinkController.php
@@ -94,7 +94,7 @@ final class SendMagicLinkController
      */
     private function buildNotification(IssuedToken $issued, string $channel, MagicLinkConfig $config): MagicLinkNotification
     {
-        $minutes = (int) ceil($config->ttl() / 60);
+        $minutes = (int) ceil($config->ttlFor($channel) / 60);
 
         $actionUrl = $channel === 'link'
             ? URL::temporarySignedRoute(

--- a/src/Stores/DefaultTokenStore.php
+++ b/src/Stores/DefaultTokenStore.php
@@ -54,7 +54,7 @@ final readonly class DefaultTokenStore implements TokenStore
         $record->token_hash = $this->hasher->hash($plaintext);
         $record->channel = $channel;
         $record->attempts = 0;
-        $record->expires_at = $now->copy()->addSeconds($this->config->ttl());
+        $record->expires_at = $now->copy()->addSeconds($this->config->ttlFor($channel));
         $record->consumed_at = null;
         $record->save();
 

--- a/src/Support/MagicLinkConfig.php
+++ b/src/Support/MagicLinkConfig.php
@@ -40,6 +40,26 @@ final readonly class MagicLinkConfig
         return $this->int($this->config->get('email-magic-link.ttl'), 900);
     }
 
+    /**
+     * The lifetime, in seconds, for a given channel's tokens.
+     *
+     * A positive `{channel}_ttl` override wins; anything else inherits `ttl`,
+     * which the entropy guard keeps positive — so this never returns a
+     * non-positive lifetime.
+     *
+     * @param  'link'|'code'  $channel
+     */
+    public function ttlFor(string $channel): int
+    {
+        $override = $this->config->get("email-magic-link.{$channel}_ttl");
+
+        if (is_numeric($override) && (int) $override > 0) {
+            return (int) $override;
+        }
+
+        return $this->ttl();
+    }
+
     public function codeLength(): int
     {
         return $this->int($this->config->get('email-magic-link.code_length'), 8);


### PR DESCRIPTION

### Added

- Per-channel token lifetimes. The new `link_ttl` and `code_ttl` config keys give
  links and codes their own expiry — for example a shorter, hand-typed code — while
  `ttl` remains the default both inherit when an override is unset or non-positive.
  The notification's "expires in N minutes" line and the link's signed-route expiry
  follow the channel's lifetime.
