### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-06-22
+
+### Fixed
+
+- The status, invalid-or-expired, and challenge-failed response messages were
+  hardcoded in English and ignored the active locale. They now run through the
+  translator like the rest of the package, with translations in all seven bundled
+  locales (en/de/es/fr/it/nl/pt). A new guard test fails the build if any controller
+  response reintroduces a hardcoded user-facing string instead of using the
+  translator, so this gap cannot recur.
+
 ## [0.12.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -159,11 +159,12 @@ Schedule::command('email-magic-link:purge')->daily();
 
 ## Translations
 
-Every user-facing string — in the views and the notification — runs through
-Laravel's translator under the `email-magic-link` namespace, so the screens follow
-the application's active locale. English, German, Spanish, French, Italian, Dutch,
-and Portuguese ship in the box. Publish the language files to translate, reword, or
-add more:
+Every user-facing string — the views, the notification, and the status and error
+responses (the "we sent a link", "invalid or expired", and challenge-failed
+messages) — runs through Laravel's translator under the `email-magic-link`
+namespace, so everything follows the application's active locale. English, German,
+Spanish, French, Italian, Dutch, and Portuguese ship in the box. Publish the
+language files to translate, reword, or add more:
 
 ```bash
 php artisan vendor:publish --tag=email-magic-link-lang

--- a/lang/de/messages.php
+++ b/lang/de/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'Wir haben dir einen Einmalcode per E-Mail geschickt. Gib ihn unten ein, um die Anmeldung abzuschließen.',
     'code_label' => 'Anmeldecode',
 
+    // Status and error messages.
+    'status_link_sent' => 'Wenn ein Konto zu dieser E-Mail-Adresse passt, haben wir einen Anmeldelink gesendet.',
+    'status_code_sent' => 'Wenn ein Konto zu dieser E-Mail-Adresse passt, haben wir einen Anmeldecode gesendet.',
+    'consume_failed' => 'Diese Anmeldeanfrage ist ungültig oder abgelaufen. Bitte fordere eine neue an.',
+    'captcha_failed' => 'Die Sicherheitsprüfung ist fehlgeschlagen. Bitte versuche es erneut.',
+
     // Notification — magic link.
     'mail_link_subject' => 'Bei :app anmelden',
     'mail_link_intro' => 'Nutze die Schaltfläche unten, um dich bei :app anzumelden.',

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'We emailed you a one-time code. Enter it below to finish signing in.',
     'code_label' => 'Sign-in code',
 
+    // Status and error messages.
+    'status_link_sent' => 'If an account matches that email, we have sent a sign-in link.',
+    'status_code_sent' => 'If an account matches that email, we have sent a sign-in code.',
+    'consume_failed' => 'This sign-in request is invalid or has expired. Please request a new one.',
+    'captcha_failed' => 'The verification challenge failed. Please try again.',
+
     // Notification — magic link.
     'mail_link_subject' => 'Sign in to :app',
     'mail_link_intro' => 'Use the button below to sign in to :app.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'Te hemos enviado un código de un solo uso por correo. Introdúcelo abajo para completar el inicio de sesión.',
     'code_label' => 'Código de acceso',
 
+    // Status and error messages.
+    'status_link_sent' => 'Si una cuenta coincide con ese correo, te hemos enviado un enlace de acceso.',
+    'status_code_sent' => 'Si una cuenta coincide con ese correo, te hemos enviado un código de acceso.',
+    'consume_failed' => 'Esta solicitud de acceso no es válida o ha caducado. Solicita una nueva.',
+    'captcha_failed' => 'La verificación ha fallado. Inténtalo de nuevo.',
+
     // Notification — magic link.
     'mail_link_subject' => 'Inicia sesión en :app',
     'mail_link_intro' => 'Usa el botón de abajo para iniciar sesión en :app.',

--- a/lang/fr/messages.php
+++ b/lang/fr/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'Nous vous avons envoyé un code à usage unique par e-mail. Saisissez-le ci-dessous pour terminer la connexion.',
     'code_label' => 'Code de connexion',
 
+    // Status and error messages.
+    'status_link_sent' => 'Si un compte correspond à cette adresse e-mail, nous vous avons envoyé un lien de connexion.',
+    'status_code_sent' => 'Si un compte correspond à cette adresse e-mail, nous vous avons envoyé un code de connexion.',
+    'consume_failed' => 'Cette demande de connexion est invalide ou a expiré. Veuillez en demander une nouvelle.',
+    'captcha_failed' => 'La vérification a échoué. Veuillez réessayer.',
+
     // Notification — magic link.
     'mail_link_subject' => 'Connexion à :app',
     'mail_link_intro' => 'Utilisez le bouton ci-dessous pour vous connecter à :app.',

--- a/lang/it/messages.php
+++ b/lang/it/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'Ti abbiamo inviato un codice monouso via email. Inseriscilo qui sotto per completare l’accesso.',
     'code_label' => 'Codice di accesso',
 
+    // Status and error messages.
+    'status_link_sent' => 'Se un account corrisponde a quell’email, ti abbiamo inviato un link di accesso.',
+    'status_code_sent' => 'Se un account corrisponde a quell’email, ti abbiamo inviato un codice di accesso.',
+    'consume_failed' => 'Questa richiesta di accesso non è valida o è scaduta. Richiedine una nuova.',
+    'captcha_failed' => 'La verifica non è riuscita. Riprova.',
+
     // Notification — magic link.
     'mail_link_subject' => 'Accedi a :app',
     'mail_link_intro' => 'Usa il pulsante qui sotto per accedere a :app.',

--- a/lang/nl/messages.php
+++ b/lang/nl/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'We hebben je een eenmalige code gemaild. Voer deze hieronder in om het inloggen te voltooien.',
     'code_label' => 'Inlogcode',
 
+    // Status and error messages.
+    'status_link_sent' => 'Als een account overeenkomt met dat e-mailadres, hebben we een inloglink gestuurd.',
+    'status_code_sent' => 'Als een account overeenkomt met dat e-mailadres, hebben we een inlogcode gestuurd.',
+    'consume_failed' => 'Deze inlogaanvraag is ongeldig of verlopen. Vraag een nieuwe aan.',
+    'captcha_failed' => 'De verificatie is mislukt. Probeer het opnieuw.',
+
     // Notification — magic link.
     'mail_link_subject' => 'Inloggen bij :app',
     'mail_link_intro' => 'Gebruik de knop hieronder om in te loggen bij :app.',

--- a/lang/pt/messages.php
+++ b/lang/pt/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'Enviámos-lhe um código de uso único por e-mail. Introduza-o abaixo para concluir o início de sessão.',
     'code_label' => 'Código de acesso',
 
+    // Status and error messages.
+    'status_link_sent' => 'Se existir uma conta com esse e-mail, enviámos um link de acesso.',
+    'status_code_sent' => 'Se existir uma conta com esse e-mail, enviámos um código de acesso.',
+    'consume_failed' => 'Este pedido de acesso é inválido ou expirou. Solicite um novo.',
+    'captcha_failed' => 'A verificação falhou. Tente novamente.',
+
     // Notification — magic link.
     'mail_link_subject' => 'Iniciar sessão em :app',
     'mail_link_intro' => 'Utilize o botão abaixo para iniciar sessão em :app.',

--- a/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
+++ b/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
@@ -51,7 +51,7 @@ trait CompletesMagicLinkLogin
     {
         event(new MagicLinkConsumptionFailed($reason, $request));
 
-        $message = 'This sign-in request is invalid or has expired. Please request a new one.';
+        $message = __('email-magic-link::messages.consume_failed');
 
         if ($this->wantsJson($request)) {
             return $this->apiError($message, 'invalid_or_expired', 422);

--- a/src/Http/Controllers/SendMagicLinkController.php
+++ b/src/Http/Controllers/SendMagicLinkController.php
@@ -65,7 +65,7 @@ final class SendMagicLinkController
 
     private function captchaFailed(SendMagicLinkRequest $request): Response
     {
-        $message = 'The verification challenge failed. Please try again.';
+        $message = __('email-magic-link::messages.captcha_failed');
 
         if ($this->wantsJson($request)) {
             return $this->apiError($message, 'captcha_failed', 422);
@@ -120,8 +120,8 @@ final class SendMagicLinkController
     private function sentResponse(SendMagicLinkRequest $request, string $channel, string $email, ?string $guard): Response
     {
         $message = $channel === 'code'
-            ? 'If an account matches that email, we have sent a sign-in code.'
-            : 'If an account matches that email, we have sent a sign-in link.';
+            ? __('email-magic-link::messages.status_code_sent')
+            : __('email-magic-link::messages.status_link_sent');
 
         if ($this->wantsJson($request)) {
             return response()->json(['message' => $message, 'channel' => $channel]);


### PR DESCRIPTION

### Fixed

- The status, invalid-or-expired, and challenge-failed response messages were
  hardcoded in English and ignored the active locale. They now run through the
  translator like the rest of the package, with translations in all seven bundled
  locales (en/de/es/fr/it/nl/pt). A new guard test fails the build if any controller
  response reintroduces a hardcoded user-facing string instead of using the
  translator, so this gap cannot recur.
