### PR TITLE
Release v0.13.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto eol=lf
+
+/.github export-ignore
+/art export-ignore
+/.gitattributes export-ignore
+/CHANGELOG.md export-ignore
+/CONTRIBUTING.md export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.3] - 2026-06-23
+
+### Changed
+
+- The Composer dist is now lean: a shipped `.gitattributes` marks the marketing
+  banner (`art/`), repository metadata (`.github/`, `CHANGELOG.md`,
+  `CONTRIBUTING.md`), and itself as `export-ignore`, so the installed package
+  carries only the runtime code, config, views, translations, and license.
+
 ## [0.13.2] - 2026-06-23
 
 ### Added


### PR DESCRIPTION

### Changed

- The Composer dist is now lean: a shipped `.gitattributes` marks the marketing
  banner (`art/`), repository metadata (`.github/`, `CHANGELOG.md`,
  `CONTRIBUTING.md`), and itself as `export-ignore`, so the installed package
  carries only the runtime code, config, views, translations, and license.
