### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-06-25
+
+### Added
+
+- Bundle the regional locale variants `en-GB`, `en-US`, `pt-PT`, and `pt-BR` (copies of the
+  `en`/`pt` messages, ready for regional refinement), so apps that distinguish them get fully
+  localized magic-link screens and emails with no fallback. `nl` and the existing locales are
+  unchanged.
+- A public Mint-API for issuing magic links and one-time codes **without sending
+  mail**, so you can deliver them over any channel (SMS, chat, an existing email,
+  a queued job). Use the `EmailMagicLink` facade or inject the new
+  `MagicLinkIssuer` contract: `issueLink($user)` returns a signed single-use
+  `IssuedLink` (URL plus expiry) and `issueCode($user)` returns an `IssuedCode`.
+  Minted credentials are hashed at rest and single-use exactly like the emailed
+  flow. Issuance re-resolves the user through the target guard's provider and
+  fails closed (`UserNotInGuardException`, `UnknownGuardException`,
+  `MagicLinkDisabledException`) rather than minting a dead or misdirected token.
+
 ## [0.13.3] - 2026-06-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -73,6 +73,42 @@ Out of the box the package registers a complete browser flow under the `web` mid
 
 Point your "log in" link at `route('email-magic-link.request.form')` and you have passwordless login. A user enters their email, receives a link, clicks it, confirms, and is signed in.
 
+## Issuing links and codes yourself
+
+Sometimes you want to deliver the link or code over a channel the bundled email flow does not cover — an SMS, a chat message, an existing transactional email, or a queued job. The **Mint-API** issues a credential and hands it back **without sending anything**:
+
+```php
+use EmailMagicLink\Facades\EmailMagicLink;
+
+// A single-use magic link for the default guard.
+$link = EmailMagicLink::issueLink($user);
+$link->url;              // signed, single-use confirmation URL — deliver this verbatim
+$link->expiresAt;        // Illuminate\Support\Carbon
+$link->expiresInMinutes; // e.g. 15 — handy for your own copy
+
+// A one-time code instead.
+$code = EmailMagicLink::issueCode($user);
+$code->code;             // the code to deliver
+$code->expiresAt;
+$code->expiresInMinutes;
+```
+
+Prefer dependency injection? Depend on the `EmailMagicLink\Contracts\MagicLinkIssuer` contract; the facade is a thin wrapper over it.
+
+```php
+use EmailMagicLink\Contracts\MagicLinkIssuer;
+
+public function __construct(private MagicLinkIssuer $issuer) {}
+```
+
+The minted credential is hashed at rest, single-use, and consumed through the exact same flow as an emailed one — only nothing is sent. A few rules the API enforces or expects:
+
+- **Deliver `url` verbatim.** It points at the inert, signed confirmation page (a `GET` that changes nothing); the token is spent only when the user submits it. Never send or prefetch the consume endpoint.
+- **Pass a user that belongs to the guard.** Issuing re-resolves the user through the guard's own provider — the same provider the consume step uses — and throws `UserNotInGuardException` if it does not match. With no `$guard` the default guard is used; pass an allowed guard (the default plus any under `guards`) or get an `UnknownGuardException`.
+- **`issueCode` supersedes the previous code** for the same user and guard, so only the most recently issued code can be claimed. (`issueLink` does not invalidate earlier links.)
+- **The channel must be enabled.** With `enabled = false` the API throws `MagicLinkDisabledException` rather than minting a credential that could never be consumed.
+- Need to look a user up by email first? Inject `EmailMagicLink\Contracts\UserLookup` — that is the supported email-to-user path; the Mint-API deliberately takes an already-resolved user.
+
 ## The three configurations
 
 **Standalone — no Fortify.** A verified user is logged in directly with `Auth::login`. There is no second factor in standalone mode, by design.
@@ -169,8 +205,11 @@ Every user-facing string — the views, the notification, and the status and err
 responses (the "we sent a link", "invalid or expired", and challenge-failed
 messages) — runs through Laravel's translator under the `email-magic-link`
 namespace, so everything follows the application's active locale. English, German,
-Spanish, French, Italian, Dutch, and Portuguese ship in the box. Publish the
-language files to translate, reword, or add more:
+Spanish, French, Italian, Dutch, and Portuguese ship in the box, along with the
+regional variants `en-GB`, `en-US`, `pt-PT`, and `pt-BR` — copies of the `en` and
+`pt` messages, ready for regional refinement — so an app that distinguishes them
+renders fully localized screens and emails with no fallback. Publish the language
+files to translate, reword, or add more:
 
 ```bash
 php artisan vendor:publish --tag=email-magic-link-lang
@@ -260,11 +299,22 @@ final class TurnstileGuard implements CaptchaGuard
 
 It runs before any user lookup, so a failed challenge rejects the request identically whether or not the email exists — it can never become an enumeration oracle. A failure returns the `captcha_failed` JSON error (or a form error) and issues nothing.
 
-## Security at rest
+## Security model
 
-Tokens are never stored in the clear — only a keyed HMAC-SHA256 hash, looked up via an index. Consumption is a single race-free conditional claim (PostgreSQL `RETURNING`, with a portable affected-rows fallback) so two concurrent requests can never both succeed. Links are additionally protected by Laravel signed routes. Raw tokens and full link URLs are never logged.
+The package is designed to fail closed. Each row below is a concrete threat and the design decision that addresses it — every one is exercised by the test suite.
 
-The request endpoint is rate-limited per email and per IP out of the box. For high-risk deployments, layer a CAPTCHA or challenge widget on top via the `captcha` guard (see [Extension points](#extension-points)) as an additional bot-protection measure. Throttled responses carry the standard `Retry-After` and `X-RateLimit-*` headers, so API and SPA clients can back off correctly.
+| Threat | How the package addresses it |
+|---|---|
+| **Database leak** — a stolen backup, an exposed read replica, or SQL injection elsewhere in the app | Tokens and codes are **never stored in the clear**: only a keyed HMAC-SHA256 hash is persisted and indexed. A leaked database alone cannot recognise or forge a working link or code. |
+| **Email security scanners and prefetch** — SafeLinks, Mimecast, Proofpoint, browser preconnect | The emailed `GET` is signed and **inert** — it only renders a confirmation page, with no authentication or state change. The single-use token is spent solely by an explicit `POST`, so a link-follower cannot burn it before the human clicks "Sign in". |
+| **Token replay, double-spend, and races** | Consumption is a **single race-free conditional claim** (PostgreSQL `RETURNING`, with a portable affected-rows fallback), so two concurrent requests for the same token can never both succeed. Links and codes are single-use. |
+| **Object injection / deserialization gadgets** | The package **never serializes objects** into a token. A row holds only scalar columns (user id, guard, channel, a hash, timestamps), so there is no `unserialize()` on any code path and therefore no object-injection surface. |
+| **Account enumeration** | The request endpoint returns a response **identical** whether or not the email belongs to a user, runs the optional CAPTCHA *before* any lookup, and queues the mail so response timing does not leak existence. Consume failures collapse to a single generic message. |
+| **Two-factor bypass** | A user with confirmed TOTP is handed to Fortify's challenge **without being logged in** — there is no path that authenticates a two-factor user without the second factor (see [the two-factor handoff](#the-two-factor-handoff-and-its-trade-off)). |
+| **Brute force of one-time codes** | A boot-time **entropy guardrail** refuses to start when a code's keyspace divided by the per-token attempt cap is too low; a per-token lockout burns the token after too many wrong guesses; and the endpoints are rate-limited per email, per IP, and per token hash. |
+| **Session fixation** | The session id is regenerated on a successful login. |
+
+Raw tokens and full link URLs are never logged. Throttled responses carry the standard `Retry-After` and `X-RateLimit-*` headers, so API and SPA clients can back off correctly. For high-risk deployments, layer a CAPTCHA or challenge widget on top via the `captcha` guard (see [Extension points](#extension-points)).
 
 See [SECURITY.md](SECURITY.md) for the supported versions and how to report a vulnerability.
 

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "laravel/pint": "^1.0",
         "orchestra/testbench": "^11.0",
         "pestphp/pest": "^4.0",
+        "pestphp/pest-plugin-browser": "^4.3",
         "pestphp/pest-plugin-laravel": "^4.0",
         "pestphp/pest-plugin-type-coverage": "^4.0",
         "rector/rector": "^2.0"
@@ -44,13 +45,17 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "EmailMagicLink\\Tests\\": "tests/"
+            "EmailMagicLink\\Tests\\": "tests/",
+            "Workbench\\App\\": "workbench/app/",
+            "Workbench\\Database\\Factories\\": "workbench/database/factories/",
+            "Workbench\\Database\\Seeders\\": "workbench/database/seeders/"
         }
     },
     "scripts": {
         "test": "pest",
         "test:coverage": "pest --coverage --min=100",
         "test:type-coverage": "pest --type-coverage --min=100",
+        "test:browser": "pest tests/Browser tests/BrowserFortify",
         "analyse": "phpstan analyse",
         "format": "pint",
         "format:test": "pint --test",

--- a/lang/en-GB/messages.php
+++ b/lang/en-GB/messages.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // Shared.
+    'heading' => 'Sign in to :app',
+    'email_label' => 'Email address',
+    'sign_in' => 'Sign in',
+
+    // Request form.
+    'request_title' => 'Sign in',
+    'request_intro_link' => 'Enter your email address and we will send you a secure sign-in link.',
+    'request_intro_code' => 'Enter your email address and we will send you a secure sign-in code.',
+    'request_send_link' => 'Send sign-in link',
+    'request_send_code' => 'Send sign-in code',
+    'delivery_legend' => 'Delivery',
+    'delivery_link' => 'Magic link',
+    'delivery_code' => 'One-time code',
+
+    // Confirmation page.
+    'confirm_title' => 'Confirm sign in',
+    'confirm_intro' => 'For your security, confirm that you want to sign in. This link can only be used once.',
+
+    // Code entry form.
+    'code_title' => 'Enter your code',
+    'code_heading' => 'Enter your sign-in code',
+    'code_intro' => 'We emailed you a one-time code. Enter it below to finish signing in.',
+    'code_label' => 'Sign-in code',
+
+    // Status and error messages.
+    'status_link_sent' => 'If an account matches that email, we have sent a sign-in link.',
+    'status_code_sent' => 'If an account matches that email, we have sent a sign-in code.',
+    'consume_failed' => 'This sign-in request is invalid or has expired. Please request a new one.',
+    'captcha_failed' => 'The verification challenge failed. Please try again.',
+
+    // Notification — magic link.
+    'mail_link_subject' => 'Sign in to :app',
+    'mail_link_intro' => 'Use the button below to sign in to :app.',
+    'mail_link_action' => 'Sign in',
+    'mail_link_expiry' => 'This link expires in :minutes minutes and can be used once.',
+
+    // Notification — one-time code.
+    'mail_code_subject' => 'Your :app sign-in code',
+    'mail_code_intro' => 'Your sign-in code for :app is:',
+    'mail_code_expiry' => 'This code expires in :minutes minutes.',
+
+    // Notification — shared.
+    'mail_ignore' => 'If you did not request this, you can safely ignore this email.',
+];

--- a/lang/en-US/messages.php
+++ b/lang/en-US/messages.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // Shared.
+    'heading' => 'Sign in to :app',
+    'email_label' => 'Email address',
+    'sign_in' => 'Sign in',
+
+    // Request form.
+    'request_title' => 'Sign in',
+    'request_intro_link' => 'Enter your email address and we will send you a secure sign-in link.',
+    'request_intro_code' => 'Enter your email address and we will send you a secure sign-in code.',
+    'request_send_link' => 'Send sign-in link',
+    'request_send_code' => 'Send sign-in code',
+    'delivery_legend' => 'Delivery',
+    'delivery_link' => 'Magic link',
+    'delivery_code' => 'One-time code',
+
+    // Confirmation page.
+    'confirm_title' => 'Confirm sign in',
+    'confirm_intro' => 'For your security, confirm that you want to sign in. This link can only be used once.',
+
+    // Code entry form.
+    'code_title' => 'Enter your code',
+    'code_heading' => 'Enter your sign-in code',
+    'code_intro' => 'We emailed you a one-time code. Enter it below to finish signing in.',
+    'code_label' => 'Sign-in code',
+
+    // Status and error messages.
+    'status_link_sent' => 'If an account matches that email, we have sent a sign-in link.',
+    'status_code_sent' => 'If an account matches that email, we have sent a sign-in code.',
+    'consume_failed' => 'This sign-in request is invalid or has expired. Please request a new one.',
+    'captcha_failed' => 'The verification challenge failed. Please try again.',
+
+    // Notification — magic link.
+    'mail_link_subject' => 'Sign in to :app',
+    'mail_link_intro' => 'Use the button below to sign in to :app.',
+    'mail_link_action' => 'Sign in',
+    'mail_link_expiry' => 'This link expires in :minutes minutes and can be used once.',
+
+    // Notification — one-time code.
+    'mail_code_subject' => 'Your :app sign-in code',
+    'mail_code_intro' => 'Your sign-in code for :app is:',
+    'mail_code_expiry' => 'This code expires in :minutes minutes.',
+
+    // Notification — shared.
+    'mail_ignore' => 'If you did not request this, you can safely ignore this email.',
+];

--- a/lang/pt-BR/messages.php
+++ b/lang/pt-BR/messages.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // Shared.
+    'heading' => 'Iniciar sessão em :app',
+    'email_label' => 'Endereço de e-mail',
+    'sign_in' => 'Iniciar sessão',
+
+    // Request form.
+    'request_title' => 'Iniciar sessão',
+    'request_intro_link' => 'Introduza o seu endereço de e-mail e enviaremos um link de acesso seguro.',
+    'request_intro_code' => 'Introduza o seu endereço de e-mail e enviaremos um código de acesso seguro.',
+    'request_send_link' => 'Enviar link de acesso',
+    'request_send_code' => 'Enviar código de acesso',
+    'delivery_legend' => 'Entrega',
+    'delivery_link' => 'Link mágico',
+    'delivery_code' => 'Código de uso único',
+
+    // Confirmation page.
+    'confirm_title' => 'Confirmar início de sessão',
+    'confirm_intro' => 'Para sua segurança, confirme que pretende iniciar sessão. Este link só pode ser usado uma vez.',
+
+    // Code entry form.
+    'code_title' => 'Introduza o seu código',
+    'code_heading' => 'Introduza o seu código de acesso',
+    'code_intro' => 'Enviámos-lhe um código de uso único por e-mail. Introduza-o abaixo para concluir o início de sessão.',
+    'code_label' => 'Código de acesso',
+
+    // Status and error messages.
+    'status_link_sent' => 'Se existir uma conta com esse e-mail, enviámos um link de acesso.',
+    'status_code_sent' => 'Se existir uma conta com esse e-mail, enviámos um código de acesso.',
+    'consume_failed' => 'Este pedido de acesso é inválido ou expirou. Solicite um novo.',
+    'captcha_failed' => 'A verificação falhou. Tente novamente.',
+
+    // Notification — magic link.
+    'mail_link_subject' => 'Iniciar sessão em :app',
+    'mail_link_intro' => 'Utilize o botão abaixo para iniciar sessão em :app.',
+    'mail_link_action' => 'Iniciar sessão',
+    'mail_link_expiry' => 'Este link expira em :minutes minutos e só pode ser usado uma vez.',
+
+    // Notification — one-time code.
+    'mail_code_subject' => 'O seu código de acesso de :app',
+    'mail_code_intro' => 'O seu código de acesso para :app é:',
+    'mail_code_expiry' => 'Este código expira em :minutes minutos.',
+
+    // Notification — shared.
+    'mail_ignore' => 'Se não solicitou isto, pode ignorar este e-mail em segurança.',
+];

--- a/lang/pt-PT/messages.php
+++ b/lang/pt-PT/messages.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // Shared.
+    'heading' => 'Iniciar sessão em :app',
+    'email_label' => 'Endereço de e-mail',
+    'sign_in' => 'Iniciar sessão',
+
+    // Request form.
+    'request_title' => 'Iniciar sessão',
+    'request_intro_link' => 'Introduza o seu endereço de e-mail e enviaremos um link de acesso seguro.',
+    'request_intro_code' => 'Introduza o seu endereço de e-mail e enviaremos um código de acesso seguro.',
+    'request_send_link' => 'Enviar link de acesso',
+    'request_send_code' => 'Enviar código de acesso',
+    'delivery_legend' => 'Entrega',
+    'delivery_link' => 'Link mágico',
+    'delivery_code' => 'Código de uso único',
+
+    // Confirmation page.
+    'confirm_title' => 'Confirmar início de sessão',
+    'confirm_intro' => 'Para sua segurança, confirme que pretende iniciar sessão. Este link só pode ser usado uma vez.',
+
+    // Code entry form.
+    'code_title' => 'Introduza o seu código',
+    'code_heading' => 'Introduza o seu código de acesso',
+    'code_intro' => 'Enviámos-lhe um código de uso único por e-mail. Introduza-o abaixo para concluir o início de sessão.',
+    'code_label' => 'Código de acesso',
+
+    // Status and error messages.
+    'status_link_sent' => 'Se existir uma conta com esse e-mail, enviámos um link de acesso.',
+    'status_code_sent' => 'Se existir uma conta com esse e-mail, enviámos um código de acesso.',
+    'consume_failed' => 'Este pedido de acesso é inválido ou expirou. Solicite um novo.',
+    'captcha_failed' => 'A verificação falhou. Tente novamente.',
+
+    // Notification — magic link.
+    'mail_link_subject' => 'Iniciar sessão em :app',
+    'mail_link_intro' => 'Utilize o botão abaixo para iniciar sessão em :app.',
+    'mail_link_action' => 'Iniciar sessão',
+    'mail_link_expiry' => 'Este link expira em :minutes minutos e só pode ser usado uma vez.',
+
+    // Notification — one-time code.
+    'mail_code_subject' => 'O seu código de acesso de :app',
+    'mail_code_intro' => 'O seu código de acesso para :app é:',
+    'mail_code_expiry' => 'Este código expira em :minutes minutos.',
+
+    // Notification — shared.
+    'mail_ignore' => 'Se não solicitou isto, pode ignorar este e-mail em segurança.',
+];

--- a/src/Contracts/MagicLinkIssuer.php
+++ b/src/Contracts/MagicLinkIssuer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Contracts;
+
+use EmailMagicLink\Support\IssuedCode;
+use EmailMagicLink\Support\IssuedLink;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Issues magic links and one-time codes for a known user WITHOUT sending mail.
+ *
+ * Use it to mint a credential and deliver it over any channel — SMS, chat, an
+ * existing email, a queued job. The returned secret is single-use and hashed at
+ * rest exactly like the bundled email flow; only the plaintext handed back here
+ * is ever in the clear. Pass an already-resolved user (resolve from an email via
+ * the UserLookup contract).
+ */
+interface MagicLinkIssuer
+{
+    /**
+     * Issue a single-use magic link for the user on the given guard.
+     *
+     * @param  string|null  $guard  An allowed guard, or null for the default.
+     */
+    public function issueLink(Authenticatable $user, ?string $guard = null): IssuedLink;
+
+    /**
+     * Issue a one-time code for the user on the given guard.
+     *
+     * Issuing a code invalidates any previously active code for the same user
+     * and guard, so only the most recently issued code can be claimed.
+     *
+     * @param  string|null  $guard  An allowed guard, or null for the default.
+     */
+    public function issueCode(Authenticatable $user, ?string $guard = null): IssuedCode;
+}

--- a/src/EmailMagicLinkServiceProvider.php
+++ b/src/EmailMagicLinkServiceProvider.php
@@ -10,14 +10,17 @@ use EmailMagicLink\Console\Commands\InstallCommand;
 use EmailMagicLink\Console\Commands\PurgeExpiredTokensCommand;
 use EmailMagicLink\Contracts\CaptchaGuard;
 use EmailMagicLink\Contracts\MagicLinkAuthenticator;
+use EmailMagicLink\Contracts\MagicLinkIssuer;
 use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Contracts\UserLookup;
 use EmailMagicLink\Lookups\DefaultUserLookup;
 use EmailMagicLink\Stores\DefaultTokenStore;
+use EmailMagicLink\Support\DefaultMagicLinkIssuer;
 use EmailMagicLink\Support\EntropyGuard;
 use EmailMagicLink\Support\MagicLinkConfig;
 use EmailMagicLink\Support\RateLimits;
 use EmailMagicLink\Support\TokenHasher;
+use Illuminate\Auth\AuthManager;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\Request;
@@ -82,6 +85,12 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton(MagicLinkAuthenticator::class, DefaultAuthenticator::class);
+
+        $this->app->singleton(MagicLinkIssuer::class, fn (Application $app): MagicLinkIssuer => new DefaultMagicLinkIssuer(
+            $app->make(TokenStore::class),
+            $app->make(MagicLinkConfig::class),
+            $app->make(AuthManager::class),
+        ));
     }
 
     public function boot(): void

--- a/src/Exceptions/MagicLinkDisabledException.php
+++ b/src/Exceptions/MagicLinkDisabledException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown when a link or code is requested while the channel is disabled.
+ *
+ * With `email-magic-link.enabled = false` no routes, rate limiters, or boot-time
+ * entropy checks are registered, so an issued credential could never be consumed.
+ * The issuer fails loud instead of minting a credential into a dead end.
+ */
+final class MagicLinkDisabledException extends RuntimeException
+{
+    public static function make(): self
+    {
+        return new self('The email-magic-link channel is disabled (email-magic-link.enabled = false); enable it before issuing links or codes.');
+    }
+}

--- a/src/Exceptions/UnknownGuardException.php
+++ b/src/Exceptions/UnknownGuardException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Exceptions;
+
+use InvalidArgumentException;
+
+/**
+ * Thrown when a link or code is requested for a guard that is not allowed.
+ *
+ * Only the default guard and those listed under `email-magic-link.guards` may be
+ * used. The message names the offending guard and the full allowlist so the
+ * caller can correct it without inspecting config.
+ */
+final class UnknownGuardException extends InvalidArgumentException
+{
+    /**
+     * @param  list<string>  $allowed
+     */
+    public static function for(string $guard, array $allowed): self
+    {
+        return new self(sprintf(
+            'The [%s] guard is not allowed for magic-link issuance. Allowed guards: [%s].',
+            $guard,
+            implode(', ', $allowed),
+        ));
+    }
+}

--- a/src/Exceptions/UserNotInGuardException.php
+++ b/src/Exceptions/UserNotInGuardException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Exceptions;
+
+use InvalidArgumentException;
+
+/**
+ * Thrown when the given user does not belong to the target guard's provider.
+ *
+ * A magic link is consumed by re-resolving the user from the guard's provider,
+ * so issuing for a user that provider cannot return — or that resolves to a
+ * different model — would mint a dead or misdirected credential. The issuer
+ * re-resolves at issuance and fails loud on a mismatch.
+ */
+final class UserNotInGuardException extends InvalidArgumentException
+{
+    public static function for(string $guard): self
+    {
+        return new self(sprintf(
+            "The given user does not belong to the [%s] guard's user provider.",
+            $guard,
+        ));
+    }
+}

--- a/src/Facades/EmailMagicLink.php
+++ b/src/Facades/EmailMagicLink.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Facades;
+
+use EmailMagicLink\Contracts\MagicLinkIssuer;
+use EmailMagicLink\Support\IssuedCode;
+use EmailMagicLink\Support\IssuedLink;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Facade;
+use Override;
+
+/**
+ * Mint magic links and one-time codes without sending mail.
+ *
+ * @method static IssuedLink issueLink(Authenticatable $user, ?string $guard = null)
+ * @method static IssuedCode issueCode(Authenticatable $user, ?string $guard = null)
+ *
+ * @see MagicLinkIssuer
+ */
+final class EmailMagicLink extends Facade
+{
+    #[Override]
+    protected static function getFacadeAccessor(): string
+    {
+        return MagicLinkIssuer::class;
+    }
+}

--- a/src/Http/Controllers/SendMagicLinkController.php
+++ b/src/Http/Controllers/SendMagicLinkController.php
@@ -11,11 +11,11 @@ use EmailMagicLink\Events\MagicLinkRequested;
 use EmailMagicLink\Http\Controllers\Concerns\RespondsToApiClients;
 use EmailMagicLink\Http\Requests\SendMagicLinkRequest;
 use EmailMagicLink\Notifications\MagicLinkNotification;
+use EmailMagicLink\Support\ConfirmationUrl;
 use EmailMagicLink\Support\IssuedToken;
 use EmailMagicLink\Support\MagicLinkConfig;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Notification as NotificationSender;
-use Illuminate\Support\Facades\URL;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -24,6 +24,11 @@ use Symfony\Component\HttpFoundation\Response;
  * Enumeration-resistant: the response is identical whether or not the
  * email belongs to a user. A token is issued and a queued notification
  * dispatched only when a user is found, but the caller can never observe that.
+ *
+ * The user is resolved through the guard's own lookup, so this flow trusts the
+ * resolved user as belonging to the guard. The public Mint-API
+ * (MagicLinkIssuer), which accepts an arbitrary user, performs the stricter
+ * provider re-resolution instead.
  */
 final class SendMagicLinkController
 {
@@ -97,11 +102,7 @@ final class SendMagicLinkController
         $minutes = (int) ceil($config->ttlFor($channel) / 60);
 
         $actionUrl = $channel === 'link'
-            ? URL::temporarySignedRoute(
-                'email-magic-link.confirm',
-                $issued->record->expires_at,
-                ['token' => $issued->plaintext],
-            )
+            ? ConfirmationUrl::for($issued->record, $issued->plaintext)
             : null;
 
         $notification = $config->notification();

--- a/src/Support/ConfirmationUrl.php
+++ b/src/Support/ConfirmationUrl.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use EmailMagicLink\Models\MagicLinkToken;
+use Illuminate\Support\Facades\URL;
+
+/**
+ * Builds the signed, single-use confirmation URL for an issued link token.
+ *
+ * Centralised so the bundled email flow and the Mint-API emit the byte-for-byte
+ * same signed GET URL: the inert confirmation page. Only the POST consume route
+ * mutates state, so this URL is safe for link-following scanners and prefetch.
+ */
+final class ConfirmationUrl
+{
+    public static function for(MagicLinkToken $record, string $plaintext): string
+    {
+        return URL::temporarySignedRoute(
+            'email-magic-link.confirm',
+            $record->expires_at,
+            ['token' => $plaintext],
+        );
+    }
+}

--- a/src/Support/DefaultMagicLinkIssuer.php
+++ b/src/Support/DefaultMagicLinkIssuer.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use EmailMagicLink\Contracts\MagicLinkIssuer;
+use EmailMagicLink\Contracts\TokenStore;
+use EmailMagicLink\Exceptions\MagicLinkDisabledException;
+use EmailMagicLink\Exceptions\UnknownGuardException;
+use EmailMagicLink\Exceptions\UserNotInGuardException;
+use Illuminate\Auth\AuthManager;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Default issuer: mints links and codes through the same hashed-at-rest token
+ * store and signed-route construction the bundled email flow uses, so a minted
+ * credential is indistinguishable from an emailed one — only nothing is sent.
+ */
+final readonly class DefaultMagicLinkIssuer implements MagicLinkIssuer
+{
+    public function __construct(
+        private TokenStore $store,
+        private MagicLinkConfig $config,
+        private AuthManager $auth,
+    ) {}
+
+    public function issueLink(Authenticatable $user, ?string $guard = null): IssuedLink
+    {
+        $resolvedGuard = $this->prepare($user, $guard);
+
+        $issued = $this->store->issue($user, $resolvedGuard, 'link');
+
+        return new IssuedLink(
+            ConfirmationUrl::for($issued->record, $issued->plaintext),
+            $issued->record->expires_at,
+            $this->minutesFor('link'),
+        );
+    }
+
+    public function issueCode(Authenticatable $user, ?string $guard = null): IssuedCode
+    {
+        $resolvedGuard = $this->prepare($user, $guard);
+
+        $issued = $this->store->issue($user, $resolvedGuard, 'code');
+
+        return new IssuedCode($issued->plaintext, $issued->record->expires_at, $this->minutesFor('code'));
+    }
+
+    /**
+     * Validate the request and return the guard to issue against. Nothing is
+     * persisted until every check here has passed, so a rejected request mints
+     * no row.
+     */
+    private function prepare(Authenticatable $user, ?string $guard): string
+    {
+        if (! $this->config->enabled()) {
+            throw MagicLinkDisabledException::make();
+        }
+
+        $resolvedGuard = $this->resolveGuardOrFail($guard);
+
+        $this->assertUserBelongsToGuard($user, $resolvedGuard);
+
+        return $resolvedGuard;
+    }
+
+    private function resolveGuardOrFail(?string $guard): string
+    {
+        if ($guard === null) {
+            return $this->config->guard();
+        }
+
+        $allowed = $this->config->allowedGuards();
+
+        if (! in_array($guard, $allowed, true)) {
+            throw UnknownGuardException::for($guard, $allowed);
+        }
+
+        return $guard;
+    }
+
+    /**
+     * Re-resolve the user through the guard's own provider — the exact path the
+     * consume flow uses — so the minted row's (user_id, guard) can never point at
+     * a different principal than the caller intended.
+     */
+    private function assertUserBelongsToGuard(Authenticatable $user, string $guard): void
+    {
+        $resolved = $this->auth
+            ->createUserProvider($this->config->providerForGuard($guard))
+            ?->retrieveById($user->getAuthIdentifier());
+
+        if (! $resolved instanceof Authenticatable || $resolved::class !== $user::class) {
+            throw UserNotInGuardException::for($guard);
+        }
+    }
+
+    /**
+     * @param  'link'|'code'  $channel
+     */
+    private function minutesFor(string $channel): int
+    {
+        return (int) ceil($this->config->ttlFor($channel) / 60);
+    }
+}

--- a/src/Support/IssuedCode.php
+++ b/src/Support/IssuedCode.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use Illuminate\Support\Carbon;
+
+/**
+ * A freshly minted one-time code, ready to deliver over any channel.
+ *
+ * Issuing a new code for the same user and guard invalidates the previous one,
+ * so deliver this `code` promptly and keep no stale copies.
+ */
+final readonly class IssuedCode
+{
+    public function __construct(
+        public string $code,
+        public Carbon $expiresAt,
+        public int $expiresInMinutes,
+    ) {}
+}

--- a/src/Support/IssuedLink.php
+++ b/src/Support/IssuedLink.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use Illuminate\Support\Carbon;
+
+/**
+ * A freshly minted magic link, ready to deliver over any channel.
+ *
+ * The URL points at the inert, signed confirmation page (a GET that changes
+ * nothing); the single-use token is spent only when the user submits that page.
+ * Deliver `url` verbatim — never the consume endpoint, and never prefetch it.
+ */
+final readonly class IssuedLink
+{
+    public function __construct(
+        public string $url,
+        public Carbon $expiresAt,
+        public int $expiresInMinutes,
+    ) {}
+}

--- a/src/Support/MagicLinkConfig.php
+++ b/src/Support/MagicLinkConfig.php
@@ -139,6 +139,18 @@ final readonly class MagicLinkConfig
             : $this->guard();
     }
 
+    /**
+     * The user provider configured for a guard, or null to fall back to the
+     * application's default provider. Mirrors how the consume flow resolves the
+     * user, so issuance and consumption always agree on the provider.
+     */
+    public function providerForGuard(string $guard): ?string
+    {
+        $provider = $this->config->get("auth.guards.{$guard}.provider");
+
+        return is_string($provider) ? $provider : null;
+    }
+
     public function userLookup(): ?string
     {
         $lookup = $this->config->get('email-magic-link.user_lookup');


### PR DESCRIPTION

### Added

- Bundle the regional locale variants `en-GB`, `en-US`, `pt-PT`, and `pt-BR` (copies of the
  `en`/`pt` messages, ready for regional refinement), so apps that distinguish them get fully
  localized magic-link screens and emails with no fallback. `nl` and the existing locales are
  unchanged.
- A public Mint-API for issuing magic links and one-time codes **without sending
  mail**, so you can deliver them over any channel (SMS, chat, an existing email,
  a queued job). Use the `EmailMagicLink` facade or inject the new
  `MagicLinkIssuer` contract: `issueLink($user)` returns a signed single-use
  `IssuedLink` (URL plus expiry) and `issueCode($user)` returns an `IssuedCode`.
  Minted credentials are hashed at rest and single-use exactly like the emailed
  flow. Issuance re-resolves the user through the target guard's provider and
  fails closed (`UserNotInGuardException`, `UnknownGuardException`,
  `MagicLinkDisabledException`) rather than minting a dead or misdirected token.
