### PR TITLE
Release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2026-07-04
+
+### Changed
+
+- Documentation and the `email-magic-link:install` command now spell out the two
+  setup steps that are easy to miss: running `php artisan migrate` to create the
+  token table, and keeping a queue worker running (or using the `sync` queue
+  connection locally) because the magic-link email is dispatched to the queue.
+
 ## [0.15.0] - 2026-06-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -48,15 +48,29 @@ Then run the installer to publish the configuration and print the next steps:
 php artisan email-magic-link:install
 ```
 
-Add `--views` to also publish the Blade views. The migration is loaded automatically, so a fresh app works without publishing anything.
+Now run your migrations to create the token table. The migration ships with the package and is loaded automatically — you do **not** need to publish it first:
 
-Prefer to do it by hand? The individual publish tags are still available:
+```bash
+php artisan migrate
+```
+
+Add `--views` to the installer to also publish the Blade views. Prefer to do it by hand? The individual publish tags are still available:
 
 ```bash
 php artisan vendor:publish --tag=email-magic-link-config
 php artisan vendor:publish --tag=email-magic-link-migrations
 php artisan vendor:publish --tag=email-magic-link-views
 ```
+
+### Sending the email
+
+The magic-link email is dispatched to the **queue**. This is deliberate: the request that issues a link returns in constant time and never blocks on the mailer, so it cannot reveal whether an account exists. The trade-off is that the mail is only actually sent once a queue worker processes the job, so **a worker has to be running**:
+
+```bash
+php artisan queue:work
+```
+
+If nothing is consuming the queue, the email never leaves — the request still succeeds, but the job just sits there. In production, keep a worker (or Horizon/Supervisor) running. For local development you can send mail synchronously instead by setting `QUEUE_CONNECTION=sync` in your `.env`.
 
 ## Quick start
 

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -39,11 +39,22 @@ final class InstallCommand extends Command
         }
 
         $this->newLine();
-        $this->info('Email Magic Link is ready.');
-        $this->line("Point your sign-in link at route('email-magic-link.request.form').");
+        $this->info('Email Magic Link is ready. Next steps:');
+        $this->newLine();
+        $this->line('  1. Create the token table by running your migrations:');
+        $this->line('       php artisan migrate');
+        $this->newLine();
+        $this->line('  2. Run a queue worker. The magic-link email is queued, so it is');
+        $this->line('     only delivered once a worker processes the job:');
+        $this->line('       php artisan queue:work');
+        $this->line('     (or set QUEUE_CONNECTION=sync in .env to send mail synchronously');
+        $this->line('     during local development).');
+        $this->newLine();
+        $this->line("  3. Point your sign-in link at route('email-magic-link.request.form').");
+        $this->newLine();
         $this->line('The migration is loaded automatically; publish it with');
         $this->line('  php artisan vendor:publish --tag=email-magic-link-migrations');
-        $this->line('if you need to customize it.');
+        $this->line('only if you need to customize it.');
 
         return self::SUCCESS;
     }


### PR DESCRIPTION

### Changed

- Documentation and the `email-magic-link:install` command now spell out the two
  setup steps that are easy to miss: running `php artisan migrate` to create the
  token table, and keeping a queue worker running (or using the `sync` queue
  connection locally) because the magic-link email is dispatched to the queue.
