### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-07-07
+
+### Added
+
+- A **resend guard** that layers an escalating cooldown plus a rolling cap on top
+  of the existing per-minute limiters, so a repeatedly clicked "send again" can no
+  longer flood an inbox. After each send the next one for that email is held back a
+  little longer (30s → 60s → 120s …, up to a ceiling) and no more than five go out
+  per rolling hour. All values are configurable under the new `resend` config block,
+  and the whole guard can be switched off with `resend.enabled = false`. It is keyed
+  on the submitted email alone — never on whether an account exists — so it stays
+  enumeration-safe, and it clears itself once a link or code for the address is
+  verified, so a real sign-in is never punished.
+- A held-back request now tells the caller how many seconds remain instead of a bare
+  error: the bundled request screen disables its button and counts down, and JSON
+  clients receive a `429` with a `Retry-After` header and a stable
+  `"error": "resend_throttled"` code. The new `resend_throttled` message ships
+  translated in every bundled locale.
+- The guard is a **public, host-consumable service**: inject the
+  `EmailMagicLink\Contracts\ResendGuard` contract and call `attempt()`, `peek()`, and
+  `reset()` with a key of your own to protect your app's own mail-sending endpoints
+  (a "resend code" button on a custom challenge, a re-invite, a reset resend). It
+  needs a cache store that supports atomic locks and fails closed on one that does
+  not.
+
 ## [0.15.2] - 2026-07-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -123,6 +123,45 @@ The minted credential is hashed at rest, single-use, and consumed through the ex
 - **The channel must be enabled.** With `enabled = false` the API throws `MagicLinkDisabledException` rather than minting a credential that could never be consumed.
 - Need to look a user up by email first? Inject `EmailMagicLink\Contracts\UserLookup` — that is the supported email-to-user path; the Mint-API deliberately takes an already-resolved user.
 
+## Holding back repeated sends
+
+Fixed-window limits cap volume but still let a "send again" button fire on every click until the cap is hit. The **resend guard** layers an escalating cooldown and a rolling cap on top: after each send the next one for that email is held back a little longer — 30 seconds, then 60, then 120, up to a ceiling — and no more than five go out per hour. It is on by default and keyed per email, so it never depends on whether an account exists. Turn it off with `resend.enabled = false`; tune it with the `resend.*` keys above.
+
+A held-back request is not a dead end: the caller is told how many seconds remain. Browsers get the count flashed to the session (the bundled request screen disables the button and counts down), and JSON clients get a `429` with a `Retry-After` header:
+
+```json
+{ "message": "Please wait 30 seconds before requesting another sign-in email.", "error": "resend_throttled" }
+```
+
+The same guard is a public service you can wrap around **your own** mail-sending endpoints — a "resend code" button on a custom challenge, a re-invite, a password-reset resend. Inject the `EmailMagicLink\Contracts\ResendGuard` contract and gate the send with a key of your choosing:
+
+```php
+use EmailMagicLink\Contracts\ResendGuard;
+
+public function __construct(private ResendGuard $guard) {}
+
+public function resend(Request $request): Response
+{
+    $decision = $this->guard->attempt('challenge:'.$request->user()->id);
+
+    if (! $decision->allowed) {
+        // Seconds until the next send is allowed — render a countdown.
+        return back()->with('retry_after', $decision->retryAfterSeconds);
+    }
+
+    // …send your mail…
+}
+```
+
+A few rules the guard follows:
+
+- **`attempt($key)` records a send only when it allows one.** A denied attempt changes no state, so a client polling the endpoint cannot push its own cooldown out. Use `peek($key)` to read the current decision without recording anything — handy for rendering a countdown before the user acts.
+- **`reset($key)` starts the key over.** Both the cooldown ladder and the rolling window clear. The package calls this for its own key once a link or code issued for the address is verified, so a real sign-in is never punished; call it yourself after your own flow completes.
+- **Pick your own key namespace.** Keys share the cache store, so prefix them (`challenge:{id}`, `invite:{email}`) to avoid colliding with the package's own `request:{email}` keys or each other. Normalize an email key yourself if you mix casings.
+- **The store must support atomic locks.** The guard takes a short lock per attempt so concurrent requests cannot each slip past the cap; the array, file, database, Redis, and Memcached stores all qualify. Point `resend.store` at one, or leave it `null` for the default cache store.
+
+**A note on the hourly cap and availability.** The cap is keyed on the submitted email, so an unauthenticated caller who knows an address can spend that address's hourly budget and keep the account from receiving a link for up to an hour. That is the nature of any per-account send cap — the same shape as the per-minute limiter, just over a longer window — and it is the price of guaranteeing a hard ceiling on mail to one inbox. The guard runs **after** the CAPTCHA (see [Extension points](#extension-points)), so in a hostile setting, enabling the `captcha` guard stops an attacker from reaching the cap at all. Raise `resend.window.max_sends`, shorten the window, or set `resend.enabled = false` if the cooldown alone is enough for your threat model.
+
 ## The three configurations
 
 **Standalone — no Fortify.** A verified user is logged in directly with `Auth::login`. There is no second factor in standalone mode, by design.
@@ -196,6 +235,10 @@ All values live in `config/email-magic-link.php`.
 | `fortify.challenge_route` | `'two-factor.login'` | Fortify challenge route name. |
 | `limiters.request` / `limiters.consume` | named limiters | Override with `RateLimiter::for()`. |
 | `limits.request` / `limits.consume` | `5` / `10` per minute | Defaults for the bundled limiters. |
+| `resend.enabled` | `true` | Escalating cooldown + rolling cap on repeated sends. |
+| `resend.cooldown` | `30` / `2` / `900` | Cooldown `base`, growth `factor`, and `max` seconds. |
+| `resend.window` | `60` / `5` | Rolling window `minutes` and `max_sends` within it. |
+| `resend.store` | `null` | Cache store for the guard; `null` uses the default. |
 
 ## One-time codes
 
@@ -216,8 +259,8 @@ Schedule::command('email-magic-link:purge')->daily();
 ## Translations
 
 Every user-facing string — the views, the notification, and the status and error
-responses (the "we sent a link", "invalid or expired", and challenge-failed
-messages) — runs through Laravel's translator under the `email-magic-link`
+responses (the "we sent a link", "invalid or expired", challenge-failed, and
+"please wait N seconds" messages) — runs through Laravel's translator under the `email-magic-link`
 namespace, so everything follows the application's active locale. English, German,
 Spanish, French, Italian, Dutch, and Portuguese ship in the box, along with the
 regional variants `en-GB`, `en-US`, `pt-PT`, and `pt-BR` — copies of the `en` and
@@ -341,9 +384,10 @@ The package is designed to fail closed. Each row below is a concrete threat and 
 | **Account enumeration** | The request endpoint returns a response **identical** whether or not the email belongs to a user, runs the optional CAPTCHA *before* any lookup, and queues the mail so response timing does not leak existence. Consume failures collapse to a single generic message. |
 | **Two-factor bypass** | A user with confirmed TOTP is handed to Fortify's challenge **without being logged in** — there is no path that authenticates a two-factor user without the second factor (see [the two-factor handoff](#the-two-factor-handoff-and-its-trade-off)). |
 | **Brute force of one-time codes** | A boot-time **entropy guardrail** refuses to start when a code's keyspace divided by the per-token attempt cap is too low; a per-token lockout burns the token after too many wrong guesses; and the endpoints are rate-limited per email, per IP, and per token hash. |
+| **Mail flooding an inbox** — a repeatedly clicked "send again" | Beyond the per-minute limiters, a **resend guard** applies an escalating cooldown (30s → 60s → 120s …) and a rolling cap (five per hour) keyed per email, so a victim's inbox cannot be flooded. It is keyed on the submitted address alone, never on whether it resolves to a user, so it stays enumeration-safe. |
 | **Session fixation** | The session id is regenerated on a successful login. |
 
-Raw tokens and full link URLs are never logged. Throttled responses carry the standard `Retry-After` and `X-RateLimit-*` headers, so API and SPA clients can back off correctly. For high-risk deployments, layer a CAPTCHA or challenge widget on top via the `captcha` guard (see [Extension points](#extension-points)).
+Raw tokens and full link URLs are never logged. Throttled responses carry the standard `Retry-After` and `X-RateLimit-*` headers, so API and SPA clients can back off correctly. The resend cap is a per-account control keyed on the submitted email and enforced *before* user lookup; because it can be used to keep a known address throttled, pair it with the `captcha` guard — which runs first — in hostile settings (see [Holding back repeated sends](#holding-back-repeated-sends)). For high-risk deployments, layer a CAPTCHA or challenge widget on top via the `captcha` guard (see [Extension points](#extension-points)).
 
 See [SECURITY.md](SECURITY.md) for the supported versions and how to report a vulnerability.
 

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "format:test": "pint --test",
         "rector": "rector process",
         "rector:test": "rector process --dry-run",
-        "mutate": "pest --mutate --everything --covered-only --parallel --min=85",
+        "mutate": "pest --mutate --everything --covered-only --parallel --processes=4 --min=85",
         "qa": [
             "@format:test",
             "@rector:test",

--- a/config/email-magic-link.php
+++ b/config/email-magic-link.php
@@ -262,4 +262,41 @@ return [
         'consume' => ['max' => 10, 'per_minutes' => 1],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Resend guard
+    |--------------------------------------------------------------------------
+    |
+    | An escalating cooldown plus a rolling cap layered on top of the fixed-
+    | window limiters above, so a repeatedly clicked "send again" cannot flood
+    | an inbox. After each send the next one for that email is held back a
+    | little longer (base, then base × factor, up to "max" seconds), and no more
+    | than "max_sends" go out per rolling "window". A held-back request is told
+    | how many seconds remain so the screen can count down instead of erroring.
+    |
+    | The same guard is available to your own mail-sending endpoints: inject the
+    | EmailMagicLink\Contracts\ResendGuard contract and call attempt()/peek()/
+    | reset() with a key of your choosing. It needs a cache store that supports
+    | atomic locks (the array, file, database, redis, and memcached stores all
+    | do); leave "store" null to use the default cache store.
+    |
+    */
+
+    'resend' => [
+        'enabled' => env('EMAIL_MAGIC_LINK_RESEND', true),
+
+        'cooldown' => [
+            'base' => 30,
+            'factor' => 2,
+            'max' => 900,
+        ],
+
+        'window' => [
+            'minutes' => 60,
+            'max_sends' => 5,
+        ],
+
+        'store' => null,
+    ],
+
 ];

--- a/lang/de/messages.php
+++ b/lang/de/messages.php
@@ -33,6 +33,7 @@ return [
     'status_code_sent' => 'Wenn ein Konto zu dieser E-Mail-Adresse passt, haben wir einen Anmeldecode gesendet.',
     'consume_failed' => 'Diese Anmeldeanfrage ist ungültig oder abgelaufen. Bitte fordere eine neue an.',
     'captcha_failed' => 'Die Sicherheitsprüfung ist fehlgeschlagen. Bitte versuche es erneut.',
+    'resend_throttled' => 'Bitte warte :seconds Sekunden, bevor du eine weitere Anmelde-E-Mail anforderst.',
 
     // Notification — magic link.
     'mail_link_subject' => 'Bei :app anmelden',

--- a/lang/en-GB/messages.php
+++ b/lang/en-GB/messages.php
@@ -33,6 +33,7 @@ return [
     'status_code_sent' => 'If an account matches that email, we have sent a sign-in code.',
     'consume_failed' => 'This sign-in request is invalid or has expired. Please request a new one.',
     'captcha_failed' => 'The verification challenge failed. Please try again.',
+    'resend_throttled' => 'Please wait :seconds seconds before requesting another sign-in email.',
 
     // Notification — magic link.
     'mail_link_subject' => 'Sign in to :app',

--- a/lang/en-US/messages.php
+++ b/lang/en-US/messages.php
@@ -33,6 +33,7 @@ return [
     'status_code_sent' => 'If an account matches that email, we have sent a sign-in code.',
     'consume_failed' => 'This sign-in request is invalid or has expired. Please request a new one.',
     'captcha_failed' => 'The verification challenge failed. Please try again.',
+    'resend_throttled' => 'Please wait :seconds seconds before requesting another sign-in email.',
 
     // Notification — magic link.
     'mail_link_subject' => 'Sign in to :app',

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -33,6 +33,7 @@ return [
     'status_code_sent' => 'If an account matches that email, we have sent a sign-in code.',
     'consume_failed' => 'This sign-in request is invalid or has expired. Please request a new one.',
     'captcha_failed' => 'The verification challenge failed. Please try again.',
+    'resend_throttled' => 'Please wait :seconds seconds before requesting another sign-in email.',
 
     // Notification — magic link.
     'mail_link_subject' => 'Sign in to :app',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -33,6 +33,7 @@ return [
     'status_code_sent' => 'Si una cuenta coincide con ese correo, te hemos enviado un código de acceso.',
     'consume_failed' => 'Esta solicitud de acceso no es válida o ha caducado. Solicita una nueva.',
     'captcha_failed' => 'La verificación ha fallado. Inténtalo de nuevo.',
+    'resend_throttled' => 'Espera :seconds segundos antes de solicitar otro correo de acceso.',
 
     // Notification — magic link.
     'mail_link_subject' => 'Inicia sesión en :app',

--- a/lang/fr/messages.php
+++ b/lang/fr/messages.php
@@ -33,6 +33,7 @@ return [
     'status_code_sent' => 'Si un compte correspond à cette adresse e-mail, nous vous avons envoyé un code de connexion.',
     'consume_failed' => 'Cette demande de connexion est invalide ou a expiré. Veuillez en demander une nouvelle.',
     'captcha_failed' => 'La vérification a échoué. Veuillez réessayer.',
+    'resend_throttled' => 'Veuillez patienter :seconds secondes avant de demander un nouvel e-mail de connexion.',
 
     // Notification — magic link.
     'mail_link_subject' => 'Connexion à :app',

--- a/lang/it/messages.php
+++ b/lang/it/messages.php
@@ -33,6 +33,7 @@ return [
     'status_code_sent' => 'Se un account corrisponde a quell’email, ti abbiamo inviato un codice di accesso.',
     'consume_failed' => 'Questa richiesta di accesso non è valida o è scaduta. Richiedine una nuova.',
     'captcha_failed' => 'La verifica non è riuscita. Riprova.',
+    'resend_throttled' => 'Attendi :seconds secondi prima di richiedere un’altra email di accesso.',
 
     // Notification — magic link.
     'mail_link_subject' => 'Accedi a :app',

--- a/lang/nl/messages.php
+++ b/lang/nl/messages.php
@@ -33,6 +33,7 @@ return [
     'status_code_sent' => 'Als een account overeenkomt met dat e-mailadres, hebben we een inlogcode gestuurd.',
     'consume_failed' => 'Deze inlogaanvraag is ongeldig of verlopen. Vraag een nieuwe aan.',
     'captcha_failed' => 'De verificatie is mislukt. Probeer het opnieuw.',
+    'resend_throttled' => 'Wacht :seconds seconden voordat je een nieuwe inlogmail aanvraagt.',
 
     // Notification — magic link.
     'mail_link_subject' => 'Inloggen bij :app',

--- a/lang/pt-BR/messages.php
+++ b/lang/pt-BR/messages.php
@@ -33,6 +33,7 @@ return [
     'status_code_sent' => 'Se existir uma conta com esse e-mail, enviámos um código de acesso.',
     'consume_failed' => 'Este pedido de acesso é inválido ou expirou. Solicite um novo.',
     'captcha_failed' => 'A verificação falhou. Tente novamente.',
+    'resend_throttled' => 'Aguarde :seconds segundos antes de solicitar outro e-mail de acesso.',
 
     // Notification — magic link.
     'mail_link_subject' => 'Iniciar sessão em :app',

--- a/lang/pt-PT/messages.php
+++ b/lang/pt-PT/messages.php
@@ -33,6 +33,7 @@ return [
     'status_code_sent' => 'Se existir uma conta com esse e-mail, enviámos um código de acesso.',
     'consume_failed' => 'Este pedido de acesso é inválido ou expirou. Solicite um novo.',
     'captcha_failed' => 'A verificação falhou. Tente novamente.',
+    'resend_throttled' => 'Aguarde :seconds segundos antes de solicitar outro e-mail de acesso.',
 
     // Notification — magic link.
     'mail_link_subject' => 'Iniciar sessão em :app',

--- a/lang/pt/messages.php
+++ b/lang/pt/messages.php
@@ -33,6 +33,7 @@ return [
     'status_code_sent' => 'Se existir uma conta com esse e-mail, enviámos um código de acesso.',
     'consume_failed' => 'Este pedido de acesso é inválido ou expirou. Solicite um novo.',
     'captcha_failed' => 'A verificação falhou. Tente novamente.',
+    'resend_throttled' => 'Aguarde :seconds segundos antes de solicitar outro e-mail de acesso.',
 
     // Notification — magic link.
     'mail_link_subject' => 'Iniciar sessão em :app',

--- a/resources/views/partials/resend-countdown.blade.php
+++ b/resources/views/partials/resend-countdown.blade.php
@@ -1,0 +1,51 @@
+{{-- Renders a polite countdown that disables the submit button after a resend
+     was held back, re-enabling it when the wait elapses. Progressive
+     enhancement only: with JavaScript off the button stays usable and the
+     server simply holds the next request back again. --}}
+@php($resendSeconds = (int) session('resend_retry_after'))
+
+@if ($resendSeconds > 0)
+    <p
+        class="eml-resend-countdown"
+        role="status"
+        aria-live="polite"
+        data-eml-resend
+        data-seconds="{{ $resendSeconds }}"
+        data-template="{{ __('email-magic-link::messages.resend_throttled', ['seconds' => '__seconds__']) }}"
+    >{{ __('email-magic-link::messages.resend_throttled', ['seconds' => $resendSeconds]) }}</p>
+
+    <script>
+        (function () {
+            var el = document.querySelector('[data-eml-resend]');
+
+            if (! el) {
+                return;
+            }
+
+            var form = (el.closest('main') || document).querySelector('form');
+            var button = form ? form.querySelector('button[type="submit"], button:not([type])') : null;
+            var template = el.getAttribute('data-template') || '';
+            var remaining = parseInt(el.getAttribute('data-seconds'), 10) || 0;
+
+            if (button) {
+                button.disabled = true;
+            }
+
+            (function tick() {
+                if (remaining <= 0) {
+                    if (button) {
+                        button.disabled = false;
+                    }
+
+                    el.textContent = '';
+
+                    return;
+                }
+
+                el.textContent = template.replace('__seconds__', remaining);
+                remaining -= 1;
+                window.setTimeout(tick, 1000);
+            })();
+        })();
+    </script>
+@endif

--- a/resources/views/request.blade.php
+++ b/resources/views/request.blade.php
@@ -30,4 +30,6 @@
 
         <button type="submit">{{ $mode === 'code' ? __('email-magic-link::messages.request_send_code') : __('email-magic-link::messages.request_send_link') }}</button>
     </form>
+
+    @include('email-magic-link::partials.resend-countdown')
 @endsection

--- a/resources/views/wirekit/request.blade.php
+++ b/resources/views/wirekit/request.blade.php
@@ -38,6 +38,8 @@
                         {{ $mode === 'code' ? __('email-magic-link::messages.request_send_code') : __('email-magic-link::messages.request_send_link') }}
                     </x-wirekit::button>
                 </x-wirekit::stack>
+
+                @include('email-magic-link::partials.resend-countdown')
             </x-wirekit::stack>
         </x-wirekit::card.body>
     </x-wirekit::card>

--- a/src/Contracts/ResendGuard.php
+++ b/src/Contracts/ResendGuard.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Contracts;
+
+use EmailMagicLink\Support\ResendDecision;
+
+/**
+ * An escalating cooldown plus a rolling send cap for mail-sending endpoints.
+ *
+ * Every allowed attempt arms a per-key cooldown that grows with each further
+ * send (base × factor, up to a ceiling) and counts toward a rolling window cap
+ * (by default five sends per hour). Both limits answer with the seconds until
+ * the next send is allowed, so callers can render a countdown instead of a
+ * bare error.
+ *
+ * The package applies the guard to its own request endpoint, keyed per email.
+ * Host applications may consume the same service for their own mail-sending
+ * endpoints (a "resend code" button on a custom challenge, for example) by
+ * injecting this contract and choosing their own keys. Prefix your keys with a
+ * namespace of your own (for example "two-factor:{user id}") — the package
+ * keys its request endpoint with "request:{email}", and keys are shared per
+ * store.
+ */
+interface ResendGuard
+{
+    /**
+     * Gate a send attempt: when allowed, the attempt is recorded (the ladder
+     * climbs one step and the send counts toward the rolling window); when
+     * denied, nothing is recorded and the decision carries the seconds until
+     * the next attempt would pass.
+     */
+    public function attempt(string $key): ResendDecision;
+
+    /**
+     * Answer what attempt() would decide right now without recording anything.
+     * Use it to render a countdown or disable a button before the user tries.
+     */
+    public function peek(string $key): ResendDecision;
+
+    /**
+     * Clear all recorded state for the key — the cooldown ladder and the
+     * rolling window start over. The package calls this once a token issued
+     * for the address is successfully verified; call it yourself after your
+     * own flow completes.
+     */
+    public function reset(string $key): void;
+}

--- a/src/EmailMagicLinkServiceProvider.php
+++ b/src/EmailMagicLinkServiceProvider.php
@@ -11,16 +11,19 @@ use EmailMagicLink\Console\Commands\PurgeExpiredTokensCommand;
 use EmailMagicLink\Contracts\CaptchaGuard;
 use EmailMagicLink\Contracts\MagicLinkAuthenticator;
 use EmailMagicLink\Contracts\MagicLinkIssuer;
+use EmailMagicLink\Contracts\ResendGuard;
 use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Contracts\UserLookup;
 use EmailMagicLink\Lookups\DefaultUserLookup;
 use EmailMagicLink\Stores\DefaultTokenStore;
 use EmailMagicLink\Support\DefaultMagicLinkIssuer;
+use EmailMagicLink\Support\DefaultResendGuard;
 use EmailMagicLink\Support\EntropyGuard;
 use EmailMagicLink\Support\MagicLinkConfig;
 use EmailMagicLink\Support\RateLimits;
 use EmailMagicLink\Support\TokenHasher;
 use Illuminate\Auth\AuthManager;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\Request;
@@ -90,6 +93,11 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
             $app->make(TokenStore::class),
             $app->make(MagicLinkConfig::class),
             $app->make(AuthManager::class),
+        ));
+
+        $this->app->singleton(ResendGuard::class, fn (Application $app): ResendGuard => new DefaultResendGuard(
+            $app->make(CacheFactory::class),
+            $app->make(MagicLinkConfig::class),
         ));
     }
 

--- a/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
+++ b/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace EmailMagicLink\Http\Controllers\Concerns;
 
 use EmailMagicLink\Contracts\MagicLinkAuthenticator;
+use EmailMagicLink\Contracts\ResendGuard;
 use EmailMagicLink\Events\MagicLinkConsumptionFailed;
 use EmailMagicLink\Events\MagicLinkVerified;
 use EmailMagicLink\Models\MagicLinkToken;
 use EmailMagicLink\Support\ClaimFailure;
+use EmailMagicLink\Support\ResendKey;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
@@ -33,6 +35,11 @@ trait CompletesMagicLinkLogin
             return $this->failedConsumption($request, $failureRoute, ClaimFailure::NotFound);
         }
 
+        // A verified token proves the address reached its owner, so clear the
+        // resend cooldown for it — covers both the direct and the two-factor
+        // handoff path, which both flow through here after the atomic claim.
+        $this->resetResendCooldown($user);
+
         event(new MagicLinkVerified($user, $request));
 
         return app(MagicLinkAuthenticator::class)->authenticate($request, $user, $token->guard, false);
@@ -45,6 +52,24 @@ trait CompletesMagicLinkLogin
         return app(AuthManager::class)
             ->createUserProvider(is_string($providerName) ? $providerName : null)
             ?->retrieveById($token->user_id);
+    }
+
+    /**
+     * Clear the resend cooldown keyed on the verified user's current email.
+     *
+     * The token stores only a user id (never the address it was issued to, by
+     * design), so this resets by the user's present email. In the ordinary case
+     * that is the address the cooldown was armed on; if the user changed it
+     * between requesting and verifying, the old key simply ages out on its own —
+     * a harmless miss, never an error, and it clears no one else's state.
+     */
+    protected function resetResendCooldown(Authenticatable $user): void
+    {
+        $email = data_get($user, 'email');
+
+        if (is_string($email) && $email !== '') {
+            app(ResendGuard::class)->reset(ResendKey::forRequest($email));
+        }
     }
 
     protected function failedConsumption(Request $request, string $failureRoute, ClaimFailure $reason): Response

--- a/src/Http/Controllers/SendMagicLinkController.php
+++ b/src/Http/Controllers/SendMagicLinkController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EmailMagicLink\Http\Controllers;
 
 use EmailMagicLink\Contracts\CaptchaGuard;
+use EmailMagicLink\Contracts\ResendGuard;
 use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Contracts\UserLookup;
 use EmailMagicLink\Events\MagicLinkRequested;
@@ -14,6 +15,8 @@ use EmailMagicLink\Notifications\MagicLinkNotification;
 use EmailMagicLink\Support\ConfirmationUrl;
 use EmailMagicLink\Support\IssuedToken;
 use EmailMagicLink\Support\MagicLinkConfig;
+use EmailMagicLink\Support\ResendDecision;
+use EmailMagicLink\Support\ResendKey;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Notification as NotificationSender;
 use Symfony\Component\HttpFoundation\Response;
@@ -40,6 +43,7 @@ final class SendMagicLinkController
         TokenStore $store,
         MagicLinkConfig $config,
         CaptchaGuard $captcha,
+        ResendGuard $resendGuard,
     ): Response {
         // Pre-issue challenge, before any user lookup, so it gates the request
         // without ever depending on whether the account exists.
@@ -48,6 +52,15 @@ final class SendMagicLinkController
         }
 
         $email = $request->email();
+
+        // Escalating cooldown + rolling cap, keyed on the submitted email alone
+        // (never on whether it resolves to a user), so it stays enumeration-safe.
+        $decision = $resendGuard->attempt(ResendKey::forRequest($email));
+
+        if (! $decision->allowed) {
+            return $this->resendThrottled($request, $decision);
+        }
+
         $channel = $this->resolveChannel($request->requestedChannel(), $config->mode());
         $guard = $config->resolveGuard($request->requestedGuard());
 
@@ -79,6 +92,26 @@ final class SendMagicLinkController
         return redirect()->route('email-magic-link.request.form')
             ->withErrors(['email' => $message])
             ->withInput($request->only('email'));
+    }
+
+    private function resendThrottled(SendMagicLinkRequest $request, ResendDecision $decision): Response
+    {
+        $seconds = $decision->retryAfterSeconds;
+        $message = __('email-magic-link::messages.resend_throttled', ['seconds' => $seconds]);
+
+        if ($this->wantsJson($request)) {
+            return $this->apiError($message, 'resend_throttled', 429)
+                ->header('Retry-After', (string) $seconds);
+        }
+
+        // Flash the remaining seconds so the request form can disable the button
+        // and count down, and carry the same Retry-After header the fixed-window
+        // throttle already sets, for parity with the rest of the flow.
+        return redirect()->route('email-magic-link.request.form')
+            ->withErrors(['email' => $message])
+            ->with('resend_retry_after', $seconds)
+            ->withInput($request->only('email'))
+            ->header('Retry-After', (string) $seconds);
     }
 
     /**

--- a/src/Support/DefaultResendGuard.php
+++ b/src/Support/DefaultResendGuard.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use EmailMagicLink\Contracts\ResendGuard;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\LockProvider;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+/**
+ * Cache-backed resend guard: an escalating cooldown plus a rolling send cap.
+ *
+ * Each recorded send is a timestamp in a per-key list, pruned to the rolling
+ * window on every read. The whole decision derives from that list: the number
+ * of sends still in the window sets both the cooldown step (base × factor per
+ * step, capped) and whether the window cap is reached. The attempt path takes a
+ * short cache lock so a burst of concurrent requests for one key cannot each
+ * read the same window and slip past the cap.
+ */
+final readonly class DefaultResendGuard implements ResendGuard
+{
+    private const string CACHE_PREFIX = 'eml:resend:';
+
+    private const string LOCK_PREFIX = 'eml:resend:lock:';
+
+    private const int LOCK_SECONDS = 5;
+
+    public function __construct(
+        private CacheFactory $cache,
+        private MagicLinkConfig $config,
+    ) {}
+
+    public function attempt(string $key): ResendDecision
+    {
+        if (! $this->config->resendEnabled()) {
+            return ResendDecision::allowed();
+        }
+
+        $store = $this->repository()->getStore();
+
+        if (! $store instanceof LockProvider) {
+            throw new RuntimeException(
+                'The [email-magic-link] resend guard needs a cache store that supports atomic locks; the configured store does not.',
+            );
+        }
+
+        $decision = ResendDecision::allowed();
+
+        $store->lock(self::LOCK_PREFIX.$this->digest($key), self::LOCK_SECONDS)
+            ->block(self::LOCK_SECONDS, function () use ($key, &$decision): void {
+                $decision = $this->evaluate($key, true);
+            });
+
+        return $decision;
+    }
+
+    public function peek(string $key): ResendDecision
+    {
+        if (! $this->config->resendEnabled()) {
+            return ResendDecision::allowed();
+        }
+
+        return $this->evaluate($key, false);
+    }
+
+    public function reset(string $key): void
+    {
+        $this->repository()->forget(self::CACHE_PREFIX.$this->digest($key));
+    }
+
+    /**
+     * Decide the key's fate against the current window, recording the send when
+     * asked to and the attempt is allowed.
+     */
+    private function evaluate(string $key, bool $record): ResendDecision
+    {
+        $now = Carbon::now()->getTimestamp();
+        $window = $this->config->resendWindow();
+        $earliest = $now - $window['seconds'];
+
+        $sends = array_values(array_filter(
+            $this->read($key),
+            static fn (int $at): bool => $at > $earliest,
+        ));
+
+        if ($sends !== []) {
+            $count = count($sends);
+            $blockedUntil = 0;
+            $reason = null;
+
+            $cooldownUntil = max($sends) + $this->cooldownAfter($count);
+
+            if ($cooldownUntil > $now) {
+                $blockedUntil = $cooldownUntil;
+                $reason = ResendDenialReason::Cooldown;
+            }
+
+            if ($count >= $window['max_sends']) {
+                $windowUntil = min($sends) + $window['seconds'];
+
+                if ($windowUntil > $blockedUntil) {
+                    $blockedUntil = $windowUntil;
+                    $reason = ResendDenialReason::WindowCap;
+                }
+            }
+
+            if ($reason instanceof ResendDenialReason) {
+                return ResendDecision::denied($reason, $blockedUntil - $now);
+            }
+        }
+
+        if ($record) {
+            $sends[] = $now;
+            $this->write($key, $sends);
+        }
+
+        return ResendDecision::allowed();
+    }
+
+    /**
+     * The cooldown, in seconds, that applies once the window holds $count sends.
+     */
+    private function cooldownAfter(int $count): int
+    {
+        $cooldown = $this->config->resendCooldown();
+        $seconds = $cooldown['base'] * ($cooldown['factor'] ** ($count - 1));
+
+        return $seconds >= $cooldown['max'] ? $cooldown['max'] : (int) $seconds;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function read(string $key): array
+    {
+        $raw = $this->repository()->get(self::CACHE_PREFIX.$this->digest($key));
+
+        if (! is_array($raw)) {
+            return [];
+        }
+
+        $sends = [];
+
+        foreach ($raw as $at) {
+            if (is_int($at)) {
+                $sends[] = $at;
+            }
+        }
+
+        return $sends;
+    }
+
+    /**
+     * @param  list<int>  $sends
+     */
+    private function write(string $key, array $sends): void
+    {
+        $ttl = max($this->config->resendWindow()['seconds'], $this->config->resendCooldown()['max']) + self::LOCK_SECONDS;
+
+        $this->repository()->put(self::CACHE_PREFIX.$this->digest($key), $sends, $ttl);
+    }
+
+    private function repository(): Repository
+    {
+        return $this->cache->store($this->config->resendStore());
+    }
+
+    private function digest(string $key): string
+    {
+        return hash('sha256', $key);
+    }
+}

--- a/src/Support/MagicLinkConfig.php
+++ b/src/Support/MagicLinkConfig.php
@@ -332,6 +332,56 @@ final readonly class MagicLinkConfig
         return $this->readLimit('consume', 10);
     }
 
+    public function resendEnabled(): bool
+    {
+        return $this->bool($this->config->get('email-magic-link.resend.enabled'), true);
+    }
+
+    /**
+     * Base cooldown, growth factor, and ceiling for the escalating resend delay.
+     * Clamped so the ladder always climbs (base and factor at least 1) and never
+     * caps below the base.
+     *
+     * @return array{base: int, factor: int, max: int}
+     */
+    public function resendCooldown(): array
+    {
+        $cooldown = $this->config->get('email-magic-link.resend.cooldown');
+        $cooldown = is_array($cooldown) ? $cooldown : [];
+
+        $base = max(1, $this->int($cooldown['base'] ?? null, 30));
+        $factor = max(1, $this->int($cooldown['factor'] ?? null, 2));
+
+        return [
+            'base' => $base,
+            'factor' => $factor,
+            'max' => max($base, $this->int($cooldown['max'] ?? null, 900)),
+        ];
+    }
+
+    /**
+     * The rolling window as seconds plus the maximum sends allowed within it.
+     *
+     * @return array{seconds: int, max_sends: int}
+     */
+    public function resendWindow(): array
+    {
+        $window = $this->config->get('email-magic-link.resend.window');
+        $window = is_array($window) ? $window : [];
+
+        return [
+            'seconds' => max(1, $this->int($window['minutes'] ?? null, 60)) * 60,
+            'max_sends' => max(1, $this->int($window['max_sends'] ?? null, 5)),
+        ];
+    }
+
+    public function resendStore(): ?string
+    {
+        $store = $this->config->get('email-magic-link.resend.store');
+
+        return is_string($store) && $store !== '' ? $store : null;
+    }
+
     /**
      * @return array{max: int, per_minutes: int}
      */

--- a/src/Support/ResendDecision.php
+++ b/src/Support/ResendDecision.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+/**
+ * Outcome of a resend-guard check: allowed, or denied with the seconds until
+ * the next attempt would pass and the limit that was hit.
+ */
+final readonly class ResendDecision
+{
+    private function __construct(
+        public bool $allowed,
+        public int $retryAfterSeconds,
+        public ?ResendDenialReason $reason,
+    ) {}
+
+    public static function allowed(): self
+    {
+        return new self(true, 0, null);
+    }
+
+    public static function denied(ResendDenialReason $reason, int $retryAfterSeconds): self
+    {
+        return new self(false, max(1, $retryAfterSeconds), $reason);
+    }
+}

--- a/src/Support/ResendDenialReason.php
+++ b/src/Support/ResendDenialReason.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+/**
+ * Why the resend guard denied an attempt.
+ */
+enum ResendDenialReason: string
+{
+    /** The escalating cooldown after a previous send has not elapsed yet. */
+    case Cooldown = 'cooldown';
+
+    /** The rolling window already contains the maximum number of sends. */
+    case WindowCap = 'window_cap';
+}

--- a/src/Support/ResendKey.php
+++ b/src/Support/ResendKey.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+/**
+ * Builds the resend-guard keys the package uses for its own endpoints.
+ *
+ * Centralizing the key shape keeps the request endpoint (which arms the guard)
+ * and the successful-login path (which resets it) in agreement, and applies the
+ * same email normalization both use so a differently-cased address still maps to
+ * the same guarded key.
+ */
+final class ResendKey
+{
+    public const string REQUEST_PREFIX = 'request:';
+
+    public static function forRequest(string $email): string
+    {
+        return self::REQUEST_PREFIX.mb_strtolower(trim($email));
+    }
+}


### PR DESCRIPTION

### Added

- A **resend guard** that layers an escalating cooldown plus a rolling cap on top
  of the existing per-minute limiters, so a repeatedly clicked "send again" can no
  longer flood an inbox. After each send the next one for that email is held back a
  little longer (30s → 60s → 120s …, up to a ceiling) and no more than five go out
  per rolling hour. All values are configurable under the new `resend` config block,
  and the whole guard can be switched off with `resend.enabled = false`. It is keyed
  on the submitted email alone — never on whether an account exists — so it stays
  enumeration-safe, and it clears itself once a link or code for the address is
  verified, so a real sign-in is never punished.
- A held-back request now tells the caller how many seconds remain instead of a bare
  error: the bundled request screen disables its button and counts down, and JSON
  clients receive a `429` with a `Retry-After` header and a stable
  `"error": "resend_throttled"` code. The new `resend_throttled` message ships
  translated in every bundled locale.
- The guard is a **public, host-consumable service**: inject the
  `EmailMagicLink\Contracts\ResendGuard` contract and call `attempt()`, `peek()`, and
  `reset()` with a key of your own to protect your app's own mail-sending endpoints
  (a "resend code" button on a custom challenge, a re-invite, a reset resend). It
  needs a cache store that supports atomic locks and fails closed on one that does
  not.
