### PR TITLE
Release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2026-07-11
+
+### Fixed
+
+- The PHP version badge in the README renders again. It relied on the
+  `packagist/php-v` shields.io route, which currently returns empty for every
+  package (a broken upstream endpoint, not specific to this package); it now reads
+  the supported PHP version from the package's own requirement via the
+  `packagist/dependency-v` route.
+
 ## [0.16.0] - 2026-07-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # Email Magic Link for Laravel
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/pushery/email-magic-link-for-laravel.svg)](https://packagist.org/packages/pushery/email-magic-link-for-laravel)
-[![PHP Version](https://img.shields.io/packagist/php-v/pushery/email-magic-link-for-laravel.svg)](https://packagist.org/packages/pushery/email-magic-link-for-laravel)
+[![PHP Version](https://img.shields.io/packagist/dependency-v/pushery/email-magic-link-for-laravel/php.svg)](https://packagist.org/packages/pushery/email-magic-link-for-laravel)
 [![PHPStan](https://img.shields.io/badge/PHPStan-max-brightgreen.svg)](https://phpstan.org/)
 [![Code Style](https://img.shields.io/badge/code%20style-pint-orange.svg)](https://laravel.com/docs/pint)
 [![License](https://img.shields.io/packagist/l/pushery/email-magic-link-for-laravel.svg)](https://packagist.org/packages/pushery/email-magic-link-for-laravel)


### PR DESCRIPTION

### Fixed

- The PHP version badge in the README renders again. It relied on the
  `packagist/php-v` shields.io route, which currently returns empty for every
  package (a broken upstream endpoint, not specific to this package); it now reads
  the supported PHP version from the package's own requirement via the
  `packagist/dependency-v` route.
