### PR TITLE
Release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-07-11
+
+### Added
+
+- **Per-link base-URL override.** `issueLink($user, baseUrl: 'https://tenant-a.example.com')`
+  builds the confirmation link for another host — useful for multi-domain or
+  multi-tenant apps. The signature is computed over the final host, so the link
+  verifies only when visited there and there is no open redirect.
+- **Optional per-link passphrase gate.** A magic link can now require a shared
+  secret — `issueLink($user, passphrase: '…')` — that the recipient enters on the
+  confirmation page before the link is consumed. The passphrase is stored only as
+  a bcrypt hash and verified before the token is spent, so a wrong passphrase
+  never consumes a use of a multi-use link, and wrong or missing passphrases fail
+  through the same generic, rate-limited response as any other bad link. This is
+  a lightweight gate, **not** two-factor authentication: a passphrase-gated link
+  for a two-factor user still hands off to the Fortify TOTP challenge afterwards —
+  the passphrase never replaces or bypasses the second factor.
+- **Bounded multi-use links.** A magic link can now be redeemed a configurable
+  number of times before it is spent — pass `issueLink($user, maxUses: 3)`, or
+  set the `max_uses` config default. Each redemption is decremented atomically in
+  the same conditional `UPDATE` that consumes the token (never read-then-write),
+  so concurrent redemptions can never exceed the limit; this is proven under real
+  PostgreSQL and MySQL 8.4 row locking. An exhausted link behaves exactly like a
+  spent or expired one, so it stays enumeration-resistant. The default is 1
+  (single-use, unchanged), and one-time codes are always single-use.
+
+  A custom `TokenStore` or `MagicLinkIssuer` implementation must match the widened
+  signatures: `TokenStore::issue()` gains optional `?int $maxUses = null` and
+  `?string $passphrase = null`, `claimLink()` gains `?string $passphrase = null`,
+  `TokenStore` adds `requiresPassphrase(string $token): bool`, and
+  `MagicLinkIssuer::issueLink()` gains optional `?int $maxUses`, `?string
+  $passphrase` and `?string $baseUrl` parameters. Callers of these methods are
+  unaffected. The token table gains `uses_remaining` and `passphrase_hash`
+  columns — run `php artisan migrate` after upgrading.
+- The response to an invalid or expired magic link or one-time code is now
+  configurable under a new `invalid_response` config block. Choose `redirect`
+  (the previous behaviour, still the default), `view` to render your own error
+  page, `abort` to return an HTTP status through your app's error page, or `json`
+  to return the `{message, error}` envelope to every client — or point `via` at
+  your own `EmailMagicLink\Contracts\InvalidLinkResponder` implementation for
+  full control. Every strategy keeps the response generic and identical for an
+  unknown versus an expired token, so the flow stays enumeration-resistant, and
+  the JSON error code is configurable via `invalid_response.error_code`.
+
 ## [0.16.1] - 2026-07-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -122,6 +122,29 @@ The minted credential is hashed at rest, single-use, and consumed through the ex
 - **`issueCode` supersedes the previous code** for the same user and guard, so only the most recently issued code can be claimed. (`issueLink` does not invalidate earlier links.)
 - **The channel must be enabled.** With `enabled = false` the API throws `MagicLinkDisabledException` rather than minting a credential that could never be consumed.
 - Need to look a user up by email first? Inject `EmailMagicLink\Contracts\UserLookup` — that is the supported email-to-user path; the Mint-API deliberately takes an already-resolved user.
+- **Build a link for another host** with `issueLink($user, baseUrl: 'https://tenant-a.example.com')` — handy for multi-domain or multi-tenant apps. The signature is computed over that final host, so the link verifies **only** when visited there; there is no open redirect.
+
+### Multi-use links
+
+A magic link is single-use by default. To hand out a link that may be redeemed a bounded number of times — a shared invite, a multi-device sign-in — pass `maxUses`:
+
+```php
+$link = $issuer->issueLink($user, maxUses: 3); // redeemable three times
+```
+
+Each redemption decrements a remaining-uses counter in the same conditional `UPDATE` that consumes the token, so concurrent redemptions can **never** exceed the limit — the count is checked and decremented atomically, never read-then-written. Once exhausted the link behaves exactly like a spent or expired one (the same generic, enumeration-resistant failure). Set the fleet-wide default with the `max_uses` config key; one-time codes are always single-use regardless.
+
+### Passphrase-gated links (not two-factor)
+
+For a high-value link you can require a shared secret — a passphrase you deliver out of band — that the recipient must enter on the confirmation page before the link is consumed:
+
+```php
+$link = $issuer->issueLink($user, passphrase: 'the-secret-you-shared');
+```
+
+The passphrase is stored only as a bcrypt hash and verified **before** the token is spent, so a wrong passphrase never consumes a use of a multi-use link. Wrong and missing passphrases fail through the same generic, rate-limited response as any other bad link, so they leak nothing. When a link carries a passphrase the confirmation page shows a passphrase field automatically.
+
+> **This is a passphrase gate, not two-factor authentication.** It is a lightweight shared-secret check, not a possession factor. The real second factor remains the [Fortify TOTP handoff](#the-two-factor-handoff-and-its-trade-off) below: a passphrase-gated link for a two-factor user still hands off to the TOTP challenge after the passphrase is accepted — the passphrase is an *additional* gate in front of that flow, never a replacement for it or a way around it.
 
 ## Holding back repeated sends
 
@@ -214,6 +237,7 @@ All values live in `config/email-magic-link.php`.
 | `ttl` | `900` | Default token lifetime in seconds. |
 | `link_ttl` | `null` | Link lifetime in seconds; inherits `ttl` when unset. |
 | `code_ttl` | `null` | Code lifetime in seconds; inherits `ttl` when unset (handy for a shorter, hand-typed code). |
+| `max_uses` | `1` | Default redemptions per link (1 = single-use). Override per link via `issueLink($user, maxUses: N)`. |
 | `code_length` | `8` | One-time code length. |
 | `code_alphabet` | unambiguous A–Z/2–9 | Alphabet for codes (governs keyspace). |
 | `max_attempts_per_token` | `5` | Hard per-token lockout for code mode. |
@@ -228,6 +252,11 @@ All values live in `config/email-magic-link.php`.
 | `routes.redirect_to` | `'/'` | Fallback redirect after login. |
 | `routes.intended` | `true` | Return to the originally requested URL after login. |
 | `api.enabled` | `false` | Direct JSON token exchange for SPA/mobile. |
+| `invalid_response.via` | `'redirect'` | Browser response for an invalid/expired link: `'redirect'`, `'view'`, `'abort'`, `'json'`, or a custom `InvalidLinkResponder` class. |
+| `invalid_response.view` | `'email-magic-link::invalid'` | View the `'view'` strategy renders (receives a `message`). |
+| `invalid_response.redirect_to` | `null` | Redirect target for the `'redirect'` strategy; `null` keeps the sign-in form. |
+| `invalid_response.abort_status` | `403` | HTTP status the `'abort'` strategy uses. |
+| `invalid_response.error_code` | `'invalid_or_expired'` | Stable JSON error code (JSON clients and the `'json'` strategy). |
 | `ui.mode` | `'auto'` | `'auto'` (WireKit views if installed) or `'blade'`. |
 | `ui.vite` | `['resources/css/app.css']` | Vite entry the WireKit layout loads. |
 | `fortify.mode` | `'auto'` | `'auto'` (on if Fortify present), `true`, or `false`. |
@@ -239,6 +268,22 @@ All values live in `config/email-magic-link.php`.
 | `resend.cooldown` | `30` / `2` / `900` | Cooldown `base`, growth `factor`, and `max` seconds. |
 | `resend.window` | `60` / `5` | Rolling window `minutes` and `max_sends` within it. |
 | `resend.store` | `null` | Cache store for the guard; `null` uses the default. |
+
+### Invalid or expired links
+
+By default an invalid or expired link redirects the browser back to the sign-in form with a generic message. Set `invalid_response.via` to change that — render your own `view`, `abort()` with an HTTP status, or return the JSON envelope to every client — or point it at a class implementing `EmailMagicLink\Contracts\InvalidLinkResponder` for full control:
+
+```php
+'invalid_response' => [
+    'via' => 'view', // 'redirect' | 'view' | 'abort' | 'json' | YourResponder::class
+    'view' => 'email-magic-link::invalid',
+    'redirect_to' => null,
+    'abort_status' => 403,
+    'error_code' => 'invalid_or_expired',
+],
+```
+
+Whichever strategy you pick, the response never reveals whether the token was unknown or merely expired, so the flow stays enumeration-resistant.
 
 ## One-time codes
 

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "test": "pest",
         "test:coverage": "pest --coverage --min=100",
         "test:type-coverage": "pest --type-coverage --min=100",
-        "test:browser": "pest tests/Browser tests/BrowserFortify",
+        "test:browser": "pest tests/Browser tests/BrowserFortify tests/BrowserWireKit",
         "test:browser:wirekit": "pest tests/BrowserWireKit",
         "test:mysql": "pest --testsuite=MySql",
         "analyse": "phpstan analyse",

--- a/config/email-magic-link.php
+++ b/config/email-magic-link.php
@@ -55,6 +55,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Multi-use links
+    |--------------------------------------------------------------------------
+    |
+    | How many times a magic link may be redeemed before it is spent. The default
+    | of 1 keeps every link single-use — the secure default for a login link.
+    | Raise it, or pass a per-link override to the Mint API's issueLink(), to hand
+    | out a link that may be redeemed a bounded number of times (a shared or
+    | multi-device invite). The count is decremented atomically on each claim, so
+    | concurrent redemptions can never exceed the limit. Codes are always
+    | single-use regardless of this value.
+    |
+    */
+
+    'max_uses' => 1,
+
+    /*
+    |--------------------------------------------------------------------------
     | One-time code (code mode)
     |--------------------------------------------------------------------------
     |
@@ -189,6 +206,37 @@ return [
 
     'api' => [
         'enabled' => false,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Invalid / expired link response
+    |--------------------------------------------------------------------------
+    |
+    | How a browser client sees an invalid or expired magic link / one-time code.
+    | "via" selects a built-in strategy — "redirect" | "view" | "abort" | "json"
+    | — or the class-string of your own EmailMagicLink\Contracts\
+    | InvalidLinkResponder implementation for full control.
+    |
+    |   redirect  back to the sign-in form (or "redirect_to") with the generic
+    |             error flashed and the email re-prefilled (the default)
+    |   view      render "view" (it receives a `message` variable)
+    |   abort     abort() with "abort_status", using your app's error page
+    |   json      return the {message, error} envelope to every client
+    |
+    | The response never reveals whether the token was unknown or merely expired,
+    | so it stays enumeration-resistant whichever strategy you pick. "error_code"
+    | is the stable machine code the JSON envelope returns (for JSON clients and
+    | the "json" strategy), analogous to the resend "resend_throttled" code.
+    |
+    */
+
+    'invalid_response' => [
+        'via' => 'redirect',
+        'view' => 'email-magic-link::invalid',
+        'redirect_to' => null,
+        'abort_status' => 403,
+        'error_code' => 'invalid_or_expired',
     ],
 
     /*

--- a/database/migrations/0001_01_01_000001_add_uses_remaining_to_magic_link_tokens.php
+++ b/database/migrations/0001_01_01_000001_add_uses_remaining_to_magic_link_tokens.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('magic_link_tokens', function (Blueprint $table): void {
+            // Remaining redemptions for a link. Default 1 preserves single-use;
+            // a link issued with a higher max_uses is decremented atomically on
+            // each claim and only marked consumed once it reaches zero. Codes are
+            // always issued with 1.
+            $table->unsignedInteger('uses_remaining')->default(1);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('magic_link_tokens', function (Blueprint $table): void {
+            $table->dropColumn('uses_remaining');
+        });
+    }
+};

--- a/database/migrations/0001_01_01_000002_add_passphrase_hash_to_magic_link_tokens.php
+++ b/database/migrations/0001_01_01_000002_add_passphrase_hash_to_magic_link_tokens.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('magic_link_tokens', function (Blueprint $table): void {
+            // Optional per-link passphrase gate. Null (the default) means the link
+            // has no passphrase; when set it holds a bcrypt hash of a shared secret
+            // that must be entered on the confirmation page before the link is
+            // consumed. It is a lightweight gate, NOT the Fortify two-factor path.
+            $table->string('passphrase_hash')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('magic_link_tokens', function (Blueprint $table): void {
+            $table->dropColumn('passphrase_hash');
+        });
+    }
+};

--- a/lang/de/messages.php
+++ b/lang/de/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'Wir haben dir einen Einmalcode per E-Mail geschickt. Gib ihn unten ein, um die Anmeldung abzuschließen.',
     'code_label' => 'Anmeldecode',
 
+    // Confirmation passphrase gate.
+    'passphrase_label' => 'Passphrase',
+
+    // Invalid link page.
+    'invalid_title' => 'Anmeldeanfrage ungültig',
+
     // Status and error messages.
     'status_link_sent' => 'Wenn ein Konto zu dieser E-Mail-Adresse passt, haben wir einen Anmeldelink gesendet.',
     'status_code_sent' => 'Wenn ein Konto zu dieser E-Mail-Adresse passt, haben wir einen Anmeldecode gesendet.',

--- a/lang/en-GB/messages.php
+++ b/lang/en-GB/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'We emailed you a one-time code. Enter it below to finish signing in.',
     'code_label' => 'Sign-in code',
 
+    // Confirmation passphrase gate.
+    'passphrase_label' => 'Passphrase',
+
+    // Invalid link page.
+    'invalid_title' => 'Sign-in request invalid',
+
     // Status and error messages.
     'status_link_sent' => 'If an account matches that email, we have sent a sign-in link.',
     'status_code_sent' => 'If an account matches that email, we have sent a sign-in code.',

--- a/lang/en-US/messages.php
+++ b/lang/en-US/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'We emailed you a one-time code. Enter it below to finish signing in.',
     'code_label' => 'Sign-in code',
 
+    // Confirmation passphrase gate.
+    'passphrase_label' => 'Passphrase',
+
+    // Invalid link page.
+    'invalid_title' => 'Sign-in request invalid',
+
     // Status and error messages.
     'status_link_sent' => 'If an account matches that email, we have sent a sign-in link.',
     'status_code_sent' => 'If an account matches that email, we have sent a sign-in code.',

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'We emailed you a one-time code. Enter it below to finish signing in.',
     'code_label' => 'Sign-in code',
 
+    // Confirmation passphrase gate.
+    'passphrase_label' => 'Passphrase',
+
+    // Invalid link page.
+    'invalid_title' => 'Sign-in request invalid',
+
     // Status and error messages.
     'status_link_sent' => 'If an account matches that email, we have sent a sign-in link.',
     'status_code_sent' => 'If an account matches that email, we have sent a sign-in code.',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'Te hemos enviado un código de un solo uso por correo. Introdúcelo abajo para completar el inicio de sesión.',
     'code_label' => 'Código de acceso',
 
+    // Confirmation passphrase gate.
+    'passphrase_label' => 'Frase de acceso',
+
+    // Invalid link page.
+    'invalid_title' => 'Solicitud de acceso no válida',
+
     // Status and error messages.
     'status_link_sent' => 'Si una cuenta coincide con ese correo, te hemos enviado un enlace de acceso.',
     'status_code_sent' => 'Si una cuenta coincide con ese correo, te hemos enviado un código de acceso.',

--- a/lang/fr/messages.php
+++ b/lang/fr/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'Nous vous avons envoyé un code à usage unique par e-mail. Saisissez-le ci-dessous pour terminer la connexion.',
     'code_label' => 'Code de connexion',
 
+    // Confirmation passphrase gate.
+    'passphrase_label' => 'Phrase secrète',
+
+    // Invalid link page.
+    'invalid_title' => 'Demande de connexion invalide',
+
     // Status and error messages.
     'status_link_sent' => 'Si un compte correspond à cette adresse e-mail, nous vous avons envoyé un lien de connexion.',
     'status_code_sent' => 'Si un compte correspond à cette adresse e-mail, nous vous avons envoyé un code de connexion.',

--- a/lang/it/messages.php
+++ b/lang/it/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'Ti abbiamo inviato un codice monouso via email. Inseriscilo qui sotto per completare l’accesso.',
     'code_label' => 'Codice di accesso',
 
+    // Confirmation passphrase gate.
+    'passphrase_label' => 'Frase di accesso',
+
+    // Invalid link page.
+    'invalid_title' => 'Richiesta di accesso non valida',
+
     // Status and error messages.
     'status_link_sent' => 'Se un account corrisponde a quell’email, ti abbiamo inviato un link di accesso.',
     'status_code_sent' => 'Se un account corrisponde a quell’email, ti abbiamo inviato un codice di accesso.',

--- a/lang/nl/messages.php
+++ b/lang/nl/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'We hebben je een eenmalige code gemaild. Voer deze hieronder in om het inloggen te voltooien.',
     'code_label' => 'Inlogcode',
 
+    // Confirmation passphrase gate.
+    'passphrase_label' => 'Wachtwoordzin',
+
+    // Invalid link page.
+    'invalid_title' => 'Inlogaanvraag ongeldig',
+
     // Status and error messages.
     'status_link_sent' => 'Als een account overeenkomt met dat e-mailadres, hebben we een inloglink gestuurd.',
     'status_code_sent' => 'Als een account overeenkomt met dat e-mailadres, hebben we een inlogcode gestuurd.',

--- a/lang/pt-BR/messages.php
+++ b/lang/pt-BR/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'Enviámos-lhe um código de uso único por e-mail. Introduza-o abaixo para concluir o início de sessão.',
     'code_label' => 'Código de acesso',
 
+    // Confirmation passphrase gate.
+    'passphrase_label' => 'Frase de acesso',
+
+    // Invalid link page.
+    'invalid_title' => 'Pedido de acesso inválido',
+
     // Status and error messages.
     'status_link_sent' => 'Se existir uma conta com esse e-mail, enviámos um link de acesso.',
     'status_code_sent' => 'Se existir uma conta com esse e-mail, enviámos um código de acesso.',

--- a/lang/pt-PT/messages.php
+++ b/lang/pt-PT/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'Enviámos-lhe um código de uso único por e-mail. Introduza-o abaixo para concluir o início de sessão.',
     'code_label' => 'Código de acesso',
 
+    // Confirmation passphrase gate.
+    'passphrase_label' => 'Frase de acesso',
+
+    // Invalid link page.
+    'invalid_title' => 'Pedido de acesso inválido',
+
     // Status and error messages.
     'status_link_sent' => 'Se existir uma conta com esse e-mail, enviámos um link de acesso.',
     'status_code_sent' => 'Se existir uma conta com esse e-mail, enviámos um código de acesso.',

--- a/lang/pt/messages.php
+++ b/lang/pt/messages.php
@@ -28,6 +28,12 @@ return [
     'code_intro' => 'Enviámos-lhe um código de uso único por e-mail. Introduza-o abaixo para concluir o início de sessão.',
     'code_label' => 'Código de acesso',
 
+    // Confirmation passphrase gate.
+    'passphrase_label' => 'Frase de acesso',
+
+    // Invalid link page.
+    'invalid_title' => 'Pedido de acesso inválido',
+
     // Status and error messages.
     'status_link_sent' => 'Se existir uma conta com esse e-mail, enviámos um link de acesso.',
     'status_code_sent' => 'Se existir uma conta com esse e-mail, enviámos um código de acesso.',

--- a/resources/views/confirm.blade.php
+++ b/resources/views/confirm.blade.php
@@ -12,6 +12,10 @@
 
     <form method="POST" action="{{ $action }}">
         @csrf
+        @if ($requiresPassphrase ?? false)
+            <label for="passphrase">{{ __('email-magic-link::messages.passphrase_label') }}</label>
+            <input type="password" name="passphrase" id="passphrase" autocomplete="off" required autofocus>
+        @endif
         <button type="submit">{{ __('email-magic-link::messages.sign_in') }}</button>
     </form>
 @endsection

--- a/resources/views/invalid.blade.php
+++ b/resources/views/invalid.blade.php
@@ -1,0 +1,10 @@
+@extends('email-magic-link::layout')
+
+@section('title', __('email-magic-link::messages.invalid_title'))
+
+@section('content')
+    <h1>{{ __('email-magic-link::messages.invalid_title') }}</h1>
+    <p>{{ $message }}</p>
+
+    <p><a href="{{ route('email-magic-link.request.form') }}">{{ __('email-magic-link::messages.sign_in') }}</a></p>
+@endsection

--- a/resources/views/wirekit/confirm.blade.php
+++ b/resources/views/wirekit/confirm.blade.php
@@ -15,6 +15,16 @@
 
                 <x-wirekit::stack as="form" method="POST" action="{{ $action }}">
                     @csrf
+                    @if ($requiresPassphrase ?? false)
+                        <x-wirekit::input
+                            name="passphrase"
+                            type="password"
+                            :label="__('email-magic-link::messages.passphrase_label')"
+                            autocomplete="off"
+                            required
+                            autofocus
+                        />
+                    @endif
                     <x-wirekit::button type="submit">{{ __('email-magic-link::messages.sign_in') }}</x-wirekit::button>
                 </x-wirekit::stack>
             </x-wirekit::stack>

--- a/src/Contracts/InvalidLinkResponder.php
+++ b/src/Contracts/InvalidLinkResponder.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Contracts;
+
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Turns an invalid-or-expired magic link / one-time code into an HTTP response
+ * for a browser client.
+ *
+ * Swap the default via the `invalid_response.via` config to a class-string of
+ * your own implementation for full control over branding and behaviour.
+ *
+ * Implementations MUST NOT vary the response by *why* the token failed — an
+ * unknown token and an expired one must be indistinguishable — so the flow stays
+ * enumeration-resistant. The single generic message is passed in already
+ * translated; do not re-derive it from the request.
+ */
+interface InvalidLinkResponder
+{
+    /**
+     * @param  string  $message  The generic, already-translated failure message.
+     * @param  string  $failureRoute  The sign-in form route to fall back to (link vs code flow).
+     */
+    public function respond(Request $request, string $message, string $failureRoute): Response;
+}

--- a/src/Contracts/MagicLinkIssuer.php
+++ b/src/Contracts/MagicLinkIssuer.php
@@ -20,11 +20,23 @@ use Illuminate\Contracts\Auth\Authenticatable;
 interface MagicLinkIssuer
 {
     /**
-     * Issue a single-use magic link for the user on the given guard.
+     * Issue a magic link for the user on the given guard.
      *
      * @param  string|null  $guard  An allowed guard, or null for the default.
+     * @param  int|null  $maxUses  How many times the link may be redeemed; null
+     *                             uses the configured `max_uses` (1 = single-use).
+     *                             Each redemption is decremented atomically, so
+     *                             concurrent claims can never exceed the limit.
+     * @param  string|null  $passphrase  A shared secret the recipient must enter
+     *                                   on the confirmation page before the link
+     *                                   is consumed. A lightweight gate, NOT the
+     *                                   Fortify two-factor challenge.
+     * @param  string|null  $baseUrl  Build the link for this host (e.g. a tenant
+     *                                domain) instead of the app's. The signature
+     *                                binds to that host, so there is no open
+     *                                redirect — the link verifies only there.
      */
-    public function issueLink(Authenticatable $user, ?string $guard = null): IssuedLink;
+    public function issueLink(Authenticatable $user, ?string $guard = null, ?int $maxUses = null, ?string $passphrase = null, ?string $baseUrl = null): IssuedLink;
 
     /**
      * Issue a one-time code for the user on the given guard.

--- a/src/Contracts/TokenStore.php
+++ b/src/Contracts/TokenStore.php
@@ -21,13 +21,27 @@ interface TokenStore
      * Issue a fresh token for the user and return the plaintext secret.
      *
      * @param  'link'|'code'  $channel
+     * @param  int|null  $maxUses  Redemptions allowed for a link; null uses the
+     *                             configured default. Ignored for codes (always 1).
+     * @param  string|null  $passphrase  An optional shared secret that must be
+     *                                   entered on the confirmation page before a
+     *                                   link is consumed. Link-only; not 2FA.
      */
-    public function issue(Authenticatable $user, string $guard, string $channel): IssuedToken;
+    public function issue(Authenticatable $user, string $guard, string $channel, ?int $maxUses = null, ?string $passphrase = null): IssuedToken;
 
     /**
      * Atomically claim a magic-link token by its plaintext value.
+     *
+     * When the link carries a passphrase, it is verified before the token is
+     * spent, so a wrong passphrase never consumes a use of a multi-use link.
      */
-    public function claimLink(string $token): ClaimResult;
+    public function claimLink(string $token, ?string $passphrase = null): ClaimResult;
+
+    /**
+     * Whether the given magic-link token is gated by a passphrase, so the
+     * confirmation page can prompt for it. Read-only; consumes nothing.
+     */
+    public function requiresPassphrase(string $token): bool;
 
     /**
      * Atomically claim a one-time code for a known user on a specific guard,

--- a/src/EmailMagicLinkServiceProvider.php
+++ b/src/EmailMagicLinkServiceProvider.php
@@ -9,11 +9,13 @@ use EmailMagicLink\Captcha\NullCaptchaGuard;
 use EmailMagicLink\Console\Commands\InstallCommand;
 use EmailMagicLink\Console\Commands\PurgeExpiredTokensCommand;
 use EmailMagicLink\Contracts\CaptchaGuard;
+use EmailMagicLink\Contracts\InvalidLinkResponder;
 use EmailMagicLink\Contracts\MagicLinkAuthenticator;
 use EmailMagicLink\Contracts\MagicLinkIssuer;
 use EmailMagicLink\Contracts\ResendGuard;
 use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Contracts\UserLookup;
+use EmailMagicLink\Http\Responses\DefaultInvalidLinkResponder;
 use EmailMagicLink\Lookups\DefaultUserLookup;
 use EmailMagicLink\Stores\DefaultTokenStore;
 use EmailMagicLink\Support\DefaultMagicLinkIssuer;
@@ -85,6 +87,12 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
             $custom = $app->make(MagicLinkConfig::class)->captcha();
 
             return $this->resolveContract($app, CaptchaGuard::class, $custom, NullCaptchaGuard::class);
+        });
+
+        $this->app->singleton(InvalidLinkResponder::class, function (Application $app): InvalidLinkResponder {
+            $custom = $app->make(MagicLinkConfig::class)->invalidLinkResponderClass();
+
+            return $this->resolveContract($app, InvalidLinkResponder::class, $custom, DefaultInvalidLinkResponder::class);
         });
 
         $this->app->singleton(MagicLinkAuthenticator::class, DefaultAuthenticator::class);

--- a/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
+++ b/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Http\Controllers\Concerns;
 
+use EmailMagicLink\Contracts\InvalidLinkResponder;
 use EmailMagicLink\Contracts\MagicLinkAuthenticator;
 use EmailMagicLink\Contracts\ResendGuard;
 use EmailMagicLink\Events\MagicLinkConsumptionFailed;
 use EmailMagicLink\Events\MagicLinkVerified;
 use EmailMagicLink\Models\MagicLinkToken;
 use EmailMagicLink\Support\ClaimFailure;
+use EmailMagicLink\Support\MagicLinkConfig;
 use EmailMagicLink\Support\ResendKey;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -76,17 +78,18 @@ trait CompletesMagicLinkLogin
     {
         event(new MagicLinkConsumptionFailed($reason, $request));
 
-        $message = __('email-magic-link::messages.consume_failed');
+        $message = (string) __('email-magic-link::messages.consume_failed');
+        $config = app(MagicLinkConfig::class);
 
+        // A client that negotiated JSON always gets the stable envelope; its
+        // shape is a fixed contract independent of the browser strategy below.
         if ($this->wantsJson($request)) {
-            return $this->apiError($message, 'invalid_or_expired', 422);
+            return $this->apiError($message, $config->invalidResponseErrorCode(), 422);
         }
 
-        // Flash the email and guard (never the secret code) so the code form can
-        // re-prefill them on retry without putting them in the redirect URL, which
-        // keeps the failure response shape identical and enumeration-resistant.
-        return redirect()->route($failureRoute)
-            ->withErrors(['email' => $message])
-            ->withInput($request->except('code'));
+        // The browser response is host-configurable (view/redirect/abort/json,
+        // or a custom class bound in the service provider) but never varies by
+        // the failure reason, so it stays enumeration-resistant.
+        return app(InvalidLinkResponder::class)->respond($request, $message, $failureRoute);
     }
 }

--- a/src/Http/Controllers/ConfirmMagicLinkController.php
+++ b/src/Http/Controllers/ConfirmMagicLinkController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Http\Controllers;
 
+use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Support\MagicLinkConfig;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
@@ -21,6 +22,7 @@ final readonly class ConfirmMagicLinkController
     public function __construct(
         private MagicLinkConfig $config,
         private Factory $views,
+        private TokenStore $store,
     ) {}
 
     public function __invoke(string $token): View
@@ -28,6 +30,7 @@ final readonly class ConfirmMagicLinkController
         return $this->views->make($this->config->view('confirm'), [
             'token' => $token,
             'action' => route('email-magic-link.consume', ['token' => $token]),
+            'requiresPassphrase' => $this->store->requiresPassphrase($token),
         ]);
     }
 }

--- a/src/Http/Controllers/ConsumeMagicLinkController.php
+++ b/src/Http/Controllers/ConsumeMagicLinkController.php
@@ -23,7 +23,9 @@ final class ConsumeMagicLinkController
 
     public function __invoke(Request $request, string $token, TokenStore $store): Response
     {
-        $result = $store->claimLink($token);
+        $passphrase = $request->string('passphrase')->toString();
+
+        $result = $store->claimLink($token, $passphrase !== '' ? $passphrase : null);
         $claimed = $result->token;
 
         if (! $result->successful || ! $claimed instanceof MagicLinkToken) {

--- a/src/Http/Responses/DefaultInvalidLinkResponder.php
+++ b/src/Http/Responses/DefaultInvalidLinkResponder.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Responses;
+
+use EmailMagicLink\Contracts\InvalidLinkResponder;
+use EmailMagicLink\Support\MagicLinkConfig;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * The bundled invalid-link responder, selected by `invalid_response.via`:
+ *
+ *   redirect  send the user back to the sign-in form (default) — or to a
+ *             configured URL — with the generic error flashed and the email
+ *             re-prefilled. Preserves the original browser behaviour.
+ *   view      render a Blade view (receives `message`), so the host owns the
+ *             branding of the error page.
+ *   abort     abort() with a configurable HTTP status, handing off to the
+ *             application's own error page.
+ *   json      return the JSON envelope ({message, error}) to every client, not
+ *             only those that negotiated JSON.
+ *
+ * Every branch uses the same generic message and never inspects why the token
+ * failed, so the response is identical for an unknown and an expired token.
+ */
+final readonly class DefaultInvalidLinkResponder implements InvalidLinkResponder
+{
+    public function __construct(private MagicLinkConfig $config) {}
+
+    public function respond(Request $request, string $message, string $failureRoute): Response
+    {
+        return match ($this->config->invalidResponseMode()) {
+            'view' => response()->view($this->config->invalidResponseView(), ['message' => $message]),
+            'abort' => abort($this->config->invalidResponseAbortStatus(), $message),
+            'json' => new JsonResponse(
+                ['message' => $message, 'error' => $this->config->invalidResponseErrorCode()],
+                422,
+            ),
+            default => $this->redirect($request, $failureRoute, $message),
+        };
+    }
+
+    private function redirect(Request $request, string $failureRoute, string $message): RedirectResponse
+    {
+        $target = $this->config->invalidResponseRedirectTo();
+
+        $redirect = $target !== null
+            ? redirect()->to($target)
+            : redirect()->route($failureRoute);
+
+        // Flash the email and guard (never the secret code) so the form can
+        // re-prefill on retry without putting them in the URL — keeping the
+        // response shape identical and enumeration-resistant.
+        return $redirect
+            ->withErrors(['email' => $message])
+            ->withInput($request->except('code'));
+    }
+}

--- a/src/Models/MagicLinkToken.php
+++ b/src/Models/MagicLinkToken.php
@@ -20,6 +20,8 @@ use Override;
  * @property string $token_hash
  * @property string $channel
  * @property int $attempts
+ * @property int $uses_remaining
+ * @property string|null $passphrase_hash
  * @property Carbon $expires_at
  * @property Carbon|null $consumed_at
  * @property Carbon|null $created_at
@@ -38,6 +40,8 @@ class MagicLinkToken extends Model
         'token_hash',
         'channel',
         'attempts',
+        'uses_remaining',
+        'passphrase_hash',
         'expires_at',
         'consumed_at',
     ];
@@ -50,6 +54,7 @@ class MagicLinkToken extends Model
     {
         return [
             'attempts' => 'integer',
+            'uses_remaining' => 'integer',
             'expires_at' => 'datetime',
             'consumed_at' => 'datetime',
         ];
@@ -63,5 +68,10 @@ class MagicLinkToken extends Model
     public function isConsumed(): bool
     {
         return $this->consumed_at !== null;
+    }
+
+    public function requiresPassphrase(): bool
+    {
+        return $this->passphrase_hash !== null;
     }
 }

--- a/src/Stores/DefaultTokenStore.php
+++ b/src/Stores/DefaultTokenStore.php
@@ -15,6 +15,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Hash;
 
 /**
  * Eloquent-backed token store.
@@ -30,10 +31,22 @@ final readonly class DefaultTokenStore implements TokenStore
         private TokenHasher $hasher,
     ) {}
 
-    public function issue(Authenticatable $user, string $guard, string $channel): IssuedToken
+    public function issue(Authenticatable $user, string $guard, string $channel, ?int $maxUses = null, ?string $passphrase = null): IssuedToken
     {
         $now = Carbon::now();
         $userId = $this->identifierOf($user);
+
+        // Only links may be redeemed more than once; a code is always single-use.
+        // A per-call override wins over the configured default, clamped to >= 1.
+        $usesRemaining = $channel === 'link'
+            ? max(1, $maxUses ?? $this->config->maxUses())
+            : 1;
+
+        // A passphrase gates links only (a code is itself the secret). Hashed with
+        // bcrypt because it is a human-chosen shared secret, not a random token.
+        $passphraseHash = $channel === 'link' && is_string($passphrase) && $passphrase !== ''
+            ? Hash::make($passphrase)
+            : null;
 
         if ($channel === 'code') {
             // Keep at most one active code per user PER GUARD so a claim is
@@ -54,6 +67,8 @@ final readonly class DefaultTokenStore implements TokenStore
         $record->token_hash = $this->hasher->hash($plaintext);
         $record->channel = $channel;
         $record->attempts = 0;
+        $record->uses_remaining = $usesRemaining;
+        $record->passphrase_hash = $passphraseHash;
         $record->expires_at = $now->copy()->addSeconds($this->config->ttlFor($channel));
         $record->consumed_at = null;
         $record->save();
@@ -61,23 +76,34 @@ final readonly class DefaultTokenStore implements TokenStore
         return new IssuedToken($plaintext, $record);
     }
 
-    public function claimLink(string $token): ClaimResult
+    public function claimLink(string $token, ?string $passphrase = null): ClaimResult
     {
         $now = Carbon::now();
         $hash = $this->hasher->hash($token);
 
-        if ($this->atomicClaim('token_hash', $hash, 'link', $now)) {
-            $model = MagicLinkToken::query()
-                ->where('token_hash', $hash)
-                ->where('channel', 'link')
-                ->first();
+        // Verify the passphrase BEFORE the atomic claim, so a wrong passphrase
+        // never spends a use of a multi-use link. A generic failure keeps the
+        // response indistinguishable from an unknown or expired token.
+        $existing = $this->findLinkByHash($hash);
 
-            return $model !== null
+        if ($existing?->passphrase_hash !== null && ! $this->passphraseMatches($passphrase, $existing->passphrase_hash)) {
+            return ClaimResult::failed(ClaimFailure::InvalidPassphrase);
+        }
+
+        if ($this->atomicClaim('token_hash', $hash, 'link', $now)) {
+            $model = $this->findLinkByHash($hash);
+
+            return $model instanceof MagicLinkToken
                 ? ClaimResult::success($model)
                 : ClaimResult::failed(ClaimFailure::NotFound);
         }
 
         return ClaimResult::failed($this->classifyLinkFailure($hash, $now));
+    }
+
+    public function requiresPassphrase(string $token): bool
+    {
+        return $this->findLinkByHash($this->hasher->hash($token))?->requiresPassphrase() ?? false;
     }
 
     public function claimCode(Authenticatable $user, string $code, string $guard): ClaimResult
@@ -170,40 +196,57 @@ final readonly class DefaultTokenStore implements TokenStore
     }
 
     /**
-     * Atomically flip consumed_at on the single active row matching the column.
+     * Atomically spend one use of the single active row matching the column.
      *
-     * Returns true only for the request that wins the race.
+     * A single conditional UPDATE decrements uses_remaining and only flips
+     * consumed_at once it reaches zero, so it is race-free for both single-use
+     * (uses_remaining 1 -> 0, consumed) and multi-use links: two concurrent
+     * claims each decrement exactly once under the row lock and can never take
+     * the counter below zero (the `uses_remaining > 0` guard fails the loser).
+     * Returns true only for a claim that spent a use.
+     *
+     * consumed_at is assigned BEFORE the decrement in the SET list on purpose:
+     * MySQL evaluates SET left to right and lets a later clause see the updated
+     * value, so the CASE must read uses_remaining while it still holds the
+     * pre-decrement count. PostgreSQL and SQLite always read the old row values,
+     * so the ordering is a no-op there — but it makes all three engines agree.
      */
     private function atomicClaim(string $column, string $value, string $channel, Carbon $now): bool
     {
         $connection = $this->connection();
 
-        if ($connection->getDriverName() === 'pgsql') {
-            $returned = $connection->select(
-                "update magic_link_tokens set consumed_at = ?, updated_at = ? where {$column} = ? and channel = ? and consumed_at is null and expires_at > ? returning id",
-                [$now, $now, $value, $channel, $now],
-            );
+        $sql = 'update magic_link_tokens set '
+            .'consumed_at = case when uses_remaining <= 1 then ? else consumed_at end, '
+            .'uses_remaining = uses_remaining - 1, updated_at = ? '
+            ."where {$column} = ? and channel = ? and consumed_at is null and expires_at > ? and uses_remaining > 0";
+        $bindings = [$now, $now, $value, $channel, $now];
 
-            return $returned !== [];
+        if ($connection->getDriverName() === 'pgsql') {
+            return $connection->select($sql.' returning id', $bindings) !== [];
         }
 
-        return $connection->table('magic_link_tokens')
-            ->where($column, $value)
-            ->where('channel', $channel)
-            ->whereNull('consumed_at')
-            ->where('expires_at', '>', $now)
-            ->update(['consumed_at' => $now, 'updated_at' => $now]) === 1;
+        return $connection->update($sql, $bindings) === 1;
+    }
+
+    private function findLinkByHash(string $hash): ?MagicLinkToken
+    {
+        return MagicLinkToken::query()
+            ->where('token_hash', $hash)
+            ->where('channel', 'link')
+            ->first();
+    }
+
+    private function passphraseMatches(?string $passphrase, string $hash): bool
+    {
+        return is_string($passphrase) && $passphrase !== '' && Hash::check($passphrase, $hash);
     }
 
     private function classifyLinkFailure(string $hash, Carbon $now): ClaimFailure
     {
-        $row = MagicLinkToken::query()
-            ->where('token_hash', $hash)
-            ->where('channel', 'link')
-            ->first();
+        $row = $this->findLinkByHash($hash);
 
         return match (true) {
-            $row === null => ClaimFailure::NotFound,
+            ! $row instanceof MagicLinkToken => ClaimFailure::NotFound,
             $row->isConsumed() => ClaimFailure::AlreadyConsumed,
             $row->isExpired($now) => ClaimFailure::Expired,
             default => ClaimFailure::NotFound,

--- a/src/Support/ClaimFailure.php
+++ b/src/Support/ClaimFailure.php
@@ -16,5 +16,6 @@ enum ClaimFailure
     case Expired;
     case AlreadyConsumed;
     case InvalidCode;
+    case InvalidPassphrase;
     case LockedOut;
 }

--- a/src/Support/ConfirmationUrl.php
+++ b/src/Support/ConfirmationUrl.php
@@ -16,7 +16,34 @@ use Illuminate\Support\Facades\URL;
  */
 final class ConfirmationUrl
 {
-    public static function for(MagicLinkToken $record, string $plaintext): string
+    /**
+     * @param  string|null  $baseUrl  Override the host the link is built for (e.g.
+     *                                a tenant domain). The signature is computed
+     *                                over that final host, so the link verifies
+     *                                only when visited there — never an attacker's.
+     */
+    public static function for(MagicLinkToken $record, string $plaintext, ?string $baseUrl = null): string
+    {
+        if ($baseUrl === null || $baseUrl === '') {
+            return self::sign($record, $plaintext);
+        }
+
+        // Force the host AND scheme from the base URL for this one signing call,
+        // then restore both so no later URL generation in the request inherits
+        // the tenant host. Forcing the scheme too makes an https base URL sign as
+        // https even when the app itself is served over http.
+        URL::forceRootUrl($baseUrl);
+        URL::forceScheme(parse_url($baseUrl, PHP_URL_SCHEME) ?: '');
+
+        try {
+            return self::sign($record, $plaintext);
+        } finally {
+            URL::forceRootUrl(null);
+            URL::forceScheme('');
+        }
+    }
+
+    private static function sign(MagicLinkToken $record, string $plaintext): string
     {
         return URL::temporarySignedRoute(
             'email-magic-link.confirm',

--- a/src/Support/DefaultMagicLinkIssuer.php
+++ b/src/Support/DefaultMagicLinkIssuer.php
@@ -25,14 +25,14 @@ final readonly class DefaultMagicLinkIssuer implements MagicLinkIssuer
         private AuthManager $auth,
     ) {}
 
-    public function issueLink(Authenticatable $user, ?string $guard = null): IssuedLink
+    public function issueLink(Authenticatable $user, ?string $guard = null, ?int $maxUses = null, ?string $passphrase = null, ?string $baseUrl = null): IssuedLink
     {
         $resolvedGuard = $this->prepare($user, $guard);
 
-        $issued = $this->store->issue($user, $resolvedGuard, 'link');
+        $issued = $this->store->issue($user, $resolvedGuard, 'link', $maxUses, $passphrase);
 
         return new IssuedLink(
-            ConfirmationUrl::for($issued->record, $issued->plaintext),
+            ConfirmationUrl::for($issued->record, $issued->plaintext, $baseUrl),
             $issued->record->expires_at,
             $this->minutesFor('link'),
         );

--- a/src/Support/MagicLinkConfig.php
+++ b/src/Support/MagicLinkConfig.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Support;
 
+use EmailMagicLink\Contracts\InvalidLinkResponder;
 use EmailMagicLink\Notifications\MagicLinkNotification;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Support\Facades\View;
@@ -58,6 +59,15 @@ final readonly class MagicLinkConfig
         }
 
         return $this->ttl();
+    }
+
+    /**
+     * The default number of times a link may be redeemed. Clamped to at least 1,
+     * so it can never mint a link that is dead on arrival.
+     */
+    public function maxUses(): int
+    {
+        return max(1, $this->int($this->config->get('email-magic-link.max_uses'), 1));
     }
 
     public function codeLength(): int
@@ -226,6 +236,74 @@ final readonly class MagicLinkConfig
     public function apiEnabled(): bool
     {
         return $this->bool($this->config->get('email-magic-link.api.enabled'), false);
+    }
+
+    /**
+     * A custom invalid-link responder class named by `via`, or null to use the
+     * bundled default. Only a `via` that names a class implementing
+     * {@see InvalidLinkResponder} counts; the built-in strategy keywords
+     * (view/redirect/abort/json) return null and are handled by the default.
+     *
+     * @return class-string<InvalidLinkResponder>|null
+     */
+    public function invalidLinkResponderClass(): ?string
+    {
+        $via = $this->config->get('email-magic-link.invalid_response.via');
+
+        return is_string($via) && is_a($via, InvalidLinkResponder::class, true) ? $via : null;
+    }
+
+    /**
+     * The built-in invalid-link strategy. Any value that is not a recognised
+     * strategy (including a custom responder class-string, handled separately)
+     * falls back to the enumeration-safe redirect.
+     *
+     * @return 'redirect'|'view'|'abort'|'json'
+     */
+    public function invalidResponseMode(): string
+    {
+        return match ($this->string($this->config->get('email-magic-link.invalid_response.via'), 'redirect')) {
+            'view' => 'view',
+            'abort' => 'abort',
+            'json' => 'json',
+            default => 'redirect',
+        };
+    }
+
+    public function invalidResponseView(): string
+    {
+        return $this->string(
+            $this->config->get('email-magic-link.invalid_response.view'),
+            'email-magic-link::invalid',
+        );
+    }
+
+    /**
+     * Where the redirect strategy sends the user; null keeps them on the sign-in
+     * form (with the error flashed), which is the default.
+     */
+    public function invalidResponseRedirectTo(): ?string
+    {
+        $to = $this->config->get('email-magic-link.invalid_response.redirect_to');
+
+        return is_string($to) && $to !== '' ? $to : null;
+    }
+
+    public function invalidResponseAbortStatus(): int
+    {
+        return $this->int($this->config->get('email-magic-link.invalid_response.abort_status'), 403);
+    }
+
+    /**
+     * The stable machine-readable code the JSON envelope returns for an
+     * invalid/expired link, so a client can branch on it without parsing prose.
+     */
+    public function invalidResponseErrorCode(): string
+    {
+        return $this->string(
+            $this->config->get('email-magic-link.invalid_response.error_code'),
+            'invalid_or_expired',
+        );
     }
 
     /**


### PR DESCRIPTION

### Added

- **Per-link base-URL override.** `issueLink($user, baseUrl: 'https://tenant-a.example.com')`
  builds the confirmation link for another host — useful for multi-domain or
  multi-tenant apps. The signature is computed over the final host, so the link
  verifies only when visited there and there is no open redirect.
- **Optional per-link passphrase gate.** A magic link can now require a shared
  secret — `issueLink($user, passphrase: '…')` — that the recipient enters on the
  confirmation page before the link is consumed. The passphrase is stored only as
  a bcrypt hash and verified before the token is spent, so a wrong passphrase
  never consumes a use of a multi-use link, and wrong or missing passphrases fail
  through the same generic, rate-limited response as any other bad link. This is
  a lightweight gate, **not** two-factor authentication: a passphrase-gated link
  for a two-factor user still hands off to the Fortify TOTP challenge afterwards —
  the passphrase never replaces or bypasses the second factor.
- **Bounded multi-use links.** A magic link can now be redeemed a configurable
  number of times before it is spent — pass `issueLink($user, maxUses: 3)`, or
  set the `max_uses` config default. Each redemption is decremented atomically in
  the same conditional `UPDATE` that consumes the token (never read-then-write),
  so concurrent redemptions can never exceed the limit; this is proven under real
  PostgreSQL and MySQL 8.4 row locking. An exhausted link behaves exactly like a
  spent or expired one, so it stays enumeration-resistant. The default is 1
  (single-use, unchanged), and one-time codes are always single-use.

  A custom `TokenStore` or `MagicLinkIssuer` implementation must match the widened
  signatures: `TokenStore::issue()` gains optional `?int $maxUses = null` and
  `?string $passphrase = null`, `claimLink()` gains `?string $passphrase = null`,
  `TokenStore` adds `requiresPassphrase(string $token): bool`, and
  `MagicLinkIssuer::issueLink()` gains optional `?int $maxUses`, `?string
  $passphrase` and `?string $baseUrl` parameters. Callers of these methods are
  unaffected. The token table gains `uses_remaining` and `passphrase_hash`
  columns — run `php artisan migrate` after upgrading.
- The response to an invalid or expired magic link or one-time code is now
  configurable under a new `invalid_response` config block. Choose `redirect`
  (the previous behaviour, still the default), `view` to render your own error
  page, `abort` to return an HTTP status through your app's error page, or `json`
  to return the `{message, error}` envelope to every client — or point `via` at
  your own `EmailMagicLink\Contracts\InvalidLinkResponder` implementation for
  full control. Every strategy keeps the response generic and identical for an
  unknown versus an expired token, so the flow stays enumeration-resistant, and
  the JSON error code is configurable via `invalid_response.error_code`.
