### PR TITLE
Release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,83 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2026-08-03
+
+### Fixed
+
+- **The CSP nonce is found again.** `AutoScriptNonce` looked for a global `csp_nonce()`
+  function. That function was introduced in spatie/laravel-csp 2.10.3 and does not exist in
+  **any** 3.x release — every 3.x version publishes `autoload.psr-4` and no `autoload.files`,
+  so it cannot define a global function at all. Detection therefore returned `null` for every
+  application on the current series, the resend countdown's inline script shipped with no
+  nonce, and a strict policy blocked it **silently** — the countdown never ran and the button
+  stayed live, so a reader who clicked too early met a rejection instead of a visible wait.
+
+  It now reads the `csp-nonce` container binding that package actually registers — the same
+  one its own `@cspNonce` directive reads — and keeps the function as a fallback for
+  applications that define one themselves. Both are probed by name, so this package still
+  references none of that package's symbols and stays installable without it.
+
+  Reported independently by four consuming applications, which is what a failure with no error
+  message costs.
+
+- **The WireKit screens can be served under a strict policy at all.** The same nonce now
+  reaches three more tags that a strict policy rejects just as hard: the WireKit layout's
+  inline `<style>` block — which was this package's own, and had never carried one — and the
+  `<link>` and `<script>` WireKit itself writes, both of which accept a nonce as of WireKit
+  2.24.0. Under a policy built on `'strict-dynamic'` the nonce is the only thing that grants a
+  tag, so before this the screen rendered unstyled with nothing in the logs.
+
+- **The WireKit layout emitted its two script tags in the wrong order.** `@wirekitScripts`
+  registers WireKit's Alpine plugins on the `alpine:init` event and `@livewireScripts` is what
+  boots Alpine, so WireKit has to come first — WireKit's own installer writes exactly that order
+  when it generates a layout. This layout had them reversed, which can cost the one-time-code
+  field its auto-advance and its paste distribution while the field still accepts typing one box
+  at a time. Nothing caught it because the browser suite asserts the screens render *styled*, and
+  styling is CSS; a missed plugin registration is invisible to it. A rendering guard now pins the
+  order.
+
+- US spelling on the published surface. Eight British spellings had accumulated across four
+  source files, a Blade view and this changelog.
+
+### Changed
+
+- **The one-time-code screen renders the boxed field for every alphabet.** WireKit's
+  `otp-input` used to accept digits only and enforced it four ways, so the shipped default
+  alphabet — `ABCDEFGHJKMNPQRSTUVWXYZ23456789`, mostly letters — could not be typed into it:
+  every keystroke was discarded and the boxes stayed empty. This package worked around that by
+  rendering a single monospace field whenever the alphabet contained letters. WireKit 2.24.0
+  added an `alphabet` prop that derives the typing filter, the paste filter, the keyboard hint
+  and the validation pattern from one value, so the workaround is gone and the boxed field is
+  back for everyone. A single-case alphabet is now matched case-insensitively too, so a code
+  typed in lowercase is accepted rather than silently refused.
+
+  **If you published `resources/views/vendor/email-magic-link/wirekit/`, republish it** to pick
+  this up. Nothing else changes: the plain Blade screens use a single field either way, and the
+  flow, routes and validation are untouched.
+
+- **A host that cannot grant `'unsafe-eval'` no longer has to give up the WireKit look.**
+  Setting WireKit's own `wirekit.scripts.bundle` to `'csp'` serves a build made against Alpine's
+  CSP distribution. The documentation used to say the only option was `ui.mode = 'blade'`; it
+  now names both.
+
+### Changed — development only
+
+Nothing in this section changes what the package does at runtime. It is recorded because
+`composer.json` and `CONTRIBUTING.md` are part of the published package, so a reader of the
+public repository sees the difference.
+
+- **The development toolchain moved to Pest 5**, together with its plugin set (browser,
+  Laravel, type-coverage, plus the PHPStan extension, the Rector set, the agent helper and
+  the evals plugin). The published requirement is unchanged and still `php: ^8.4` — on
+  8.4.0 the runtime tree resolves to the Symfony 8.0 line and installs cleanly. **Working
+  on the package now needs PHP 8.4.1 or newer**, because the test toolchain pulls Symfony
+  8.1, which requires it. `CONTRIBUTING.md` says so, and names the confusing symptom: on
+  exactly 8.4.0 `composer install` fails citing `symfony/process`, never Pest.
+- `composer.json` gains a `test:evals` script and drops the finite `process-timeout` in
+  favour of `0`. Both are development-side only; no runtime dependency, autoload entry or
+  published default moved.
+
 ## [0.19.0] - 2026-07-26
 
 ### Added
@@ -173,7 +250,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   columns — run `php artisan migrate` after upgrading.
 - The response to an invalid or expired magic link or one-time code is now
   configurable under a new `invalid_response` config block. Choose `redirect`
-  (the previous behaviour, still the default), `view` to render your own error
+  (the previous behavior, still the default), `view` to render your own error
   page, `abort` to return an HTTP status through your app's error page, or `json`
   to return the `{message, error}` envelope to every client — or point `via` at
   your own `EmailMagicLink\Contracts\InvalidLinkResponder` implementation for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,17 @@
 Thanks for considering a contribution. This package holds itself to a strict quality
 bar, and every pull request is expected to keep all of the gates green.
 
+## Local requirements
+
+**PHP 8.4.1 or newer to work on the package, even though the package itself installs on
+8.4.0.** The two floors are different on purpose. The published requirement stays `^8.4`
+and it is honest: on 8.4.0 Composer resolves the runtime tree to the Symfony 8.0 line and
+installs cleanly. The development toolchain does not have that option — Pest 5 and the
+current Laravel test stack pull Symfony 8.1, which requires `php >=8.4.1`.
+
+So on exactly 8.4.0 `composer install` fails here with a message naming `symfony/process`
+or `phpunit/phpunit`, never Pest. Upgrade the patch version; nothing else is wrong.
+
 ## Getting started
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -25,16 +25,20 @@
         "laravel/framework": "^13.0"
     },
     "require-dev": {
+        "cweagans/composer-patches": "^1.7",
         "larastan/larastan": "^3.0",
         "laravel/fortify": "^1.0",
         "laravel/pao": "^1.1",
         "laravel/pint": "^1.0",
         "orchestra/testbench": "^11.0",
-        "pestphp/pest": "^4.0",
-        "pestphp/pest-plugin-browser": "^4.3",
-        "pestphp/pest-plugin-laravel": "^4.0",
-        "pestphp/pest-plugin-type-coverage": "^4.0",
-        "phpstan/phpstan": "^2.2 !=2.2.6",
+        "pestphp/pest": "^5.0",
+        "pestphp/pest-plugin-agent": "^5.0",
+        "pestphp/pest-plugin-browser": "^5.0",
+        "pestphp/pest-plugin-evals": "^5.0",
+        "pestphp/pest-plugin-laravel": "^5.0",
+        "pestphp/pest-plugin-phpstan": "^5.0",
+        "pestphp/pest-plugin-rector": "^5.0",
+        "pestphp/pest-plugin-type-coverage": "^5.0",
         "pushery/wirekit": "^2.8",
         "rector/rector": "^2.0",
         "spaze/phpstan-disallowed-calls": "^4.12"
@@ -62,9 +66,10 @@
         "test:type-coverage": "pest --type-coverage --min=100",
         "test:browser": "pest tests/Browser tests/BrowserFortify tests/BrowserWireKit",
         "test:browser:wirekit": "pest tests/BrowserWireKit",
+        "test:evals": "pest tests/Evals --evals",
         "test:mysql": "pest --testsuite=MySql",
         "test:database": "pest --testsuite=Postgres,MySql",
-        "analyse": "phpstan analyse",
+        "analyse": "phpstan analyse --memory-limit=1G",
         "format": "pint",
         "format:test": "pint --test",
         "rector": "rector process",
@@ -80,13 +85,14 @@
         ]
     },
     "config": {
-        "process-timeout": 1800,
+        "process-timeout": 0,
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true
         }
     },
     "extra": {
+        "composer-exit-on-patch-failure": true,
         "laravel": {
             "providers": [
                 "EmailMagicLink\\EmailMagicLinkServiceProvider"

--- a/config/email-magic-link.php
+++ b/config/email-magic-link.php
@@ -259,19 +259,34 @@ return [
     | alongside) a Vite build — e.g. a CDN bundle or an asset() path.
     |
     | "script_nonce" names a class implementing EmailMagicLink\Contracts\
-    | ScriptNonce, which supplies the CSP nonce for the resend countdown's inline
-    | script. Leave it null and the package detects the csp_nonce() helper
-    | (spatie/laravel-csp) by itself; set it only when your nonce lives elsewhere.
-    | Under a strict policy without a nonce the script is blocked SILENTLY — the
-    | countdown simply never runs.
+    | ScriptNonce, which supplies the CSP nonce for every tag the bundled screens
+    | emit that a strict policy would otherwise reject: the resend countdown's
+    | inline script, the WireKit layout's inline stylesheet, and the <link> and
+    | <script> WireKit itself writes. Leave it null and the package finds the nonce
+    | on its own — it reads the "csp-nonce" container binding spatie/laravel-csp
+    | registers, and falls back to a global csp_nonce() function for hosts that
+    | define one. Set it only when your nonce lives somewhere else entirely.
+    | Under a strict policy without a nonce these are blocked SILENTLY — the
+    | countdown simply never runs, and the screen renders unstyled.
     |
-    | That nonce is the whole story for the plain screens. The WireKit screens
-    | additionally need "unsafe-eval" in script-src, because WireKit's components
-    | are driven by Alpine and Alpine compiles its expressions with the Function
-    | constructor. On these screens that is the one-time-code field: without it,
-    | the digit boxes stop advancing and pasting a code stops filling them — again
-    | silently. A host whose policy cannot grant "unsafe-eval" should set mode to
-    | "blade"; the plain screens carry the same flow and use no Alpine.
+    | The WireKit screens have one more requirement, and it is not a nonce. Their
+    | components are driven by Alpine, and Alpine's default build compiles its
+    | expressions with the Function constructor, which needs "unsafe-eval" in
+    | script-src. On these screens that is the one-time-code field: without it the
+    | digit boxes stop advancing and pasting a code stops filling them — again
+    | silently. Two answers, and only one of them is complete:
+    |
+    |   1. Set mode to "blade". The plain screens carry the same flow and use no
+    |      Alpine and no Livewire, so they need no exception at all. This is the
+    |      reliable answer.
+    |   2. Set wirekit.scripts.bundle to "csp" (WireKit 2.24.0+) — most of the way,
+    |      not all of it. That bundle is built against Alpine's CSP distribution, so
+    |      WireKit's own components stop needing "unsafe-eval". But @wirekitScripts
+    |      force-injects Livewire's assets (that is how Alpine reaches a page with no
+    |      Livewire component on it), and Livewire compiles its own directives at
+    |      runtime the same way — so the page still needs "unsafe-eval" unless the app
+    |      also runs Livewire's CSP distribution. The bundle also CONTAINS Alpine and
+    |      starts it, so an app on it must not load its own as well.
     |
     */
 

--- a/resources/views/wirekit/code.blade.php
+++ b/resources/views/wirekit/code.blade.php
@@ -29,50 +29,38 @@
                         :error="$errors->first('email')"
                     />
 
-                    {{-- WireKit's otp-input is digits-only, and it enforces that in four
-                         places: typing a non-digit clears the box, pasting strips every
-                         non-digit, inputmode is numeric and pattern is [0-9]. Our default
-                         code_alphabet is ABCDEFGHJKMNPQRSTUVWXYZ23456789 — mostly letters —
-                         so on a default install those boxes cannot accept the code the
-                         package itself just mailed out.
+                    {{-- One field for every alphabet, since WireKit 2.24.0 gave otp-input
+                         an `alphabet` prop. Until then it was digits-only and
+                         enforced it in four places — typing a non-digit cleared the box,
+                         pasting stripped every non-digit, inputmode was numeric and pattern
+                         was [0-9] — while our default code_alphabet is
+                         ABCDEFGHJKMNPQRSTUVWXYZ23456789, mostly letters. A default install
+                         therefore had boxes that could not accept the code the package had
+                         just mailed. This view carried a branch to a single mono input for
+                         exactly that case; the branch is now retired.
 
-                         So the boxed field is used only when the configured alphabet really
-                         is numeric, where it is both correct and nicer. Otherwise this falls
-                         back to a single mono input, which is what the plain Blade twin has
-                         always used. Nothing is lost by the swap: auto-advance, arrow
-                         navigation and paste-distribution are all digit-filtered, so they
-                         never worked for a letter in the first place.
+                         The prop derives every one of those four constraints from the
+                         alphabet, which is why one argument is enough here — a prop that
+                         only relaxed `pattern` would have left the keystroke filter
+                         discarding the code while looking configurable.
 
-                         The single field goes away again once WireKit's boxed input
-                         accepts a caller-supplied alphabet; the branch is reported
-                         upstream and tracked privately until then. --}}
+                         Passed only when it is non-empty: the component falls back to
+                         digits on an empty alphabet, and silently handing it '' would
+                         reinstate the exact failure this replaces. An unconfigured code
+                         channel never reaches this screen anyway — EntropyGuard refuses to
+                         mint from defaults it was not given — so this is the belt for a
+                         config that is present but blank. --}}
                     @php($emlAlphabet = (string) config('email-magic-link.code_alphabet', ''))
                     @php($emlCodeLength = (int) config('email-magic-link.code_length', 8))
 
-                    @if ($emlAlphabet !== '' && ctype_digit($emlAlphabet))
-                        <x-wirekit::otp-input
-                            name="code"
-                            class="eml-otp"
-                            :length="$emlCodeLength"
-                            :label="__('email-magic-link::messages.code_label')"
-                            :error="$errors->first('code')"
-                        />
-                    @else
-                        <x-wirekit::input
-                            name="code"
-                            type="text"
-                            mono
-                            inputmode="text"
-                            autocomplete="one-time-code"
-                            autocapitalize="characters"
-                            spellcheck="false"
-                            :maxlength="$emlCodeLength"
-                            :label="__('email-magic-link::messages.code_label')"
-                            :error="$errors->first('code')"
-                            required
-                            autofocus
-                        />
-                    @endif
+                    <x-wirekit::otp-input
+                        name="code"
+                        class="eml-otp"
+                        :length="$emlCodeLength"
+                        :alphabet="$emlAlphabet !== '' ? $emlAlphabet : '0123456789'"
+                        :label="__('email-magic-link::messages.code_label')"
+                        :error="$errors->first('code')"
+                    />
 
                     <x-wirekit::button type="submit">{{ __('email-magic-link::messages.sign_in') }}</x-wirekit::button>
                 </x-wirekit::stack>

--- a/resources/views/wirekit/layout.blade.php
+++ b/resources/views/wirekit/layout.blade.php
@@ -6,11 +6,24 @@
     <meta name="robots" content="noindex, nofollow">
     <title>@yield('title', __('email-magic-link::messages.sign_in')) &middot; {{ config('app.name') }}</title>
 
+    {{-- The application's per-response CSP nonce, or null when it has no policy.
+         Resolved once here and handed to every tag on this page that a strict
+         policy would otherwise reject: WireKit's <link> and <script>, and the
+         inline <style> below. Same seam the countdown partial uses. --}}
+    @php($emlNonce = app(\EmailMagicLink\Contracts\ScriptNonce::class)->value())
+
     {{-- WireKit's design tokens (the --color-wk-*, --padding-wk-*, --radius-wk-*
          … custom properties every component reads) ship in dist/wirekit.css and
          are injected ONLY by this directive. Without it every var(--*-wk-*)
-         resolves to nothing and the components render completely unstyled. --}}
-    @wirekitStyles
+         resolves to nothing and the components render completely unstyled.
+
+         The nonce argument arrived in WireKit 2.24.0. Under a policy
+         built on 'strict-dynamic' the nonce is the ONLY thing that grants a tag —
+         same origin is not enough — so before this the WireKit screens could not
+         be served under the very policy an auth page is most likely to carry. An
+         empty expression is what the directive already defaulted to, so a host
+         without a policy renders byte-identically. --}}
+    @wirekitStyles($emlNonce)
 
     {{-- The host's compiled stylesheet (Tailwind v4 with WireKit's views
          @source'd) supplies the component utility classes. ui.vite points at
@@ -29,7 +42,7 @@
          shell in a tiny inline stylesheet centers the sign-in screen in any
          host, scanned or not. The card's own surface, spacing, and type still
          come from the WireKit tokens loaded above. --}}
-    <style>
+    <style{!! $emlNonce === null ? '' : ' nonce="'.e($emlNonce).'"' !!}>
         :root { color-scheme: light dark; }
         body {
             margin: 0;
@@ -40,17 +53,38 @@
             color: var(--color-wk-text, CanvasText);
         }
         .eml-shell { width: 100%; max-width: 24rem; padding: 2rem; box-sizing: border-box; }
-        /* WireKit's one-time-code digits are fixed-width boxes; for a long code
-           their row is wider than a phone (and than this narrow card), so let it
-           wrap to a second line instead of forcing the page to scroll sideways. */
-        .eml-otp [role="group"] { flex-wrap: wrap; justify-content: center; }
+        /* Only the CENTERING is still ours. The `flex-wrap: wrap` half of this rule
+           was a workaround and is retired: WireKit 2.24.0 ships the
+           digit row as `flex flex-wrap gap-2`, so a long code wraps on its own.
+           It does not center the wrapped remainder, and on this 24rem card an
+           eight-digit code always wraps — two boxes hanging at the left edge under
+           a full row read as a rendering fault rather than a layout. Reaching in
+           through `role="group"` is still a consumer patch, so it stays as narrow
+           as the delta actually is. */
+        .eml-otp [role="group"] { justify-content: center; }
     </style>
 </head>
 <body>
     <main class="eml-shell">
         @yield('content')
     </main>
+    {{-- ORDER IS LOAD-BEARING, and it used to be wrong here. @wirekitScripts
+         registers WireKit's Alpine plugins on the `alpine:init` event, and
+         @livewireScripts is what BOOTS Alpine — so WireKit has to come first or
+         its plugins can miss the event they are waiting for. WireKit's own
+         installer enforces exactly this order when it writes a layout, and its
+         source says why. This layout had the two the other way round, and nothing
+         caught it: the browser suite asserts that the screens render styled, which
+         is CSS, so a missed plugin registration is invisible to it.
+
+         Nonced for the same reason as the stylesheet above. A host that cannot
+         grant 'unsafe-eval' has a lever since WireKit 2.24.0 —
+         `wirekit.scripts.bundle = 'csp'`, built against Alpine's CSP distribution
+         — but it is only half the answer here, and the docs say which half:
+         @wirekitScripts force-injects Livewire's assets so Alpine reaches a
+         pure-Blade page, and Livewire compiles its own directives at runtime the
+         same way Alpine's default build does. --}}
+    @wirekitScripts($emlNonce)
     @livewireScripts
-    @wirekitScripts
 </body>
 </html>

--- a/src/Contracts/InvalidLinkResponder.php
+++ b/src/Contracts/InvalidLinkResponder.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
  * for a browser client.
  *
  * Swap the default via the `invalid_response.via` config to a class-string of
- * your own implementation for full control over branding and behaviour.
+ * your own implementation for full control over branding and behavior.
  *
  * Implementations MUST NOT vary the response by *why* the token failed — an
  * unknown token and an expired one must be indistinguishable — so the flow stays

--- a/src/Http/Responses/DefaultInvalidLinkResponder.php
+++ b/src/Http/Responses/DefaultInvalidLinkResponder.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  *   redirect  send the user back to the sign-in form (default) — or to a
  *             configured URL — with the generic error flashed and the email
- *             re-prefilled. Preserves the original browser behaviour.
+ *             re-prefilled. Preserves the original browser behavior.
  *   view      render a Blade view (receives `message`), so the host owns the
  *             branding of the error page.
  *   abort     abort() with a configurable HTTP status, handing off to the

--- a/src/Stores/DefaultTokenStore.php
+++ b/src/Stores/DefaultTokenStore.php
@@ -144,7 +144,7 @@ final readonly class DefaultTokenStore implements TokenStore
             }
 
             if (! $this->atomicClaim('id', (string) $token->id, 'code', $now)) {
-                // Unreachable once the row lock above serialises claims; kept as a
+                // Unreachable once the row lock above serializes claims; kept as a
                 // defensive backstop that maps a losing race to a clean outcome.
                 return ClaimResult::failed(ClaimFailure::AlreadyConsumed); // @codeCoverageIgnore
             }

--- a/src/Support/AutoScriptNonce.php
+++ b/src/Support/AutoScriptNonce.php
@@ -10,25 +10,71 @@ use Throwable;
 /**
  * Finds the application's CSP nonce without the application configuring anything.
  *
- * `csp_nonce()` is the helper spatie/laravel-csp registers, and it is the common
- * case by a wide margin. Probed by name so this package never references that
- * package's symbols and stays installable without it.
+ * Two probes, in order, because the ecosystem moved and this class did not notice.
+ *
+ * 1. The container binding `csp-nonce`. That is what spatie/laravel-csp actually
+ *    registers — `$this->app->scoped('csp-nonce', …)` in its service provider — and
+ *    it is what the package's own `@cspNonce` directive reads. Scoped means one nonce
+ *    per request, so resolving it here yields the same value the policy header carries.
+ * 2. A global `csp_nonce()` function, kept for hosts that define one themselves.
+ *
+ * The order is not arbitrary, and the second probe used to be the ONLY one. That was
+ * wrong for every current consumer: `csp_nonce()` arrived in spatie/laravel-csp 2.10.3
+ * and exists nowhere in 3.x — measured against the package's own metadata, where every
+ * 3.x release publishes `autoload.psr-4` and no `autoload.files`, so it cannot register
+ * a global function at all. `function_exists('csp_nonce')` was therefore false for every
+ * v3 host, this class returned null, and the countdown script shipped with no nonce
+ * under exactly the strict policy the seam exists to serve. It failed silently, which is
+ * why it took three separate consumers to notice.
+ *
+ * Probed by name and by key so this package never references that package's symbols and
+ * stays installable without it.
  *
  * Everything here fails to NULL rather than throwing. A missing nonce degrades to
- * exactly the behaviour that shipped before the seam existed (an inline script with
+ * exactly the behavior that shipped before the seam existed (an inline script with
  * no nonce, fine under a permissive policy); an exception would take down the whole
  * sign-in screen over a progressive enhancement. That trade is the wrong way round.
  */
 final class AutoScriptNonce implements ScriptNonce
 {
     /**
-     * The helper to probe. Overridable so a test can prove the probe without
+     * The container key to probe. Overridable so a test can prove the binding path
+     * without installing a CSP package.
+     */
+    public static string $binding = 'csp-nonce';
+
+    /**
+     * The function to probe. Overridable so a test can prove the probe without
      * installing a CSP package — the name is not a callable until it exists,
      * which is the entire point of probing it.
      */
     public static string $helper = 'csp_nonce';
 
     public function value(): ?string
+    {
+        return $this->fromContainer() ?? $this->fromHelper();
+    }
+
+    private function fromContainer(): ?string
+    {
+        $container = app();
+
+        if (! $container->bound(self::$binding)) {
+            return null;
+        }
+
+        try {
+            $nonce = $container->make(self::$binding);
+        } catch (Throwable) {
+            // A binding that exists but cannot be resolved on this request — a
+            // generator needing state a console command does not have, say.
+            return null;
+        }
+
+        return $this->usable($nonce);
+    }
+
+    private function fromHelper(): ?string
     {
         $helper = self::$helper;
 
@@ -40,10 +86,20 @@ final class AutoScriptNonce implements ScriptNonce
             $nonce = $helper();
         } catch (Throwable) {
             // The helper exists but the policy is not active on this response —
-            // spatie's throws when no nonce was generated. Not our error to raise.
+            // spatie's 2.x helper throws when no nonce was generated. Not our
+            // error to raise.
             return null;
         }
 
+        return $this->usable($nonce);
+    }
+
+    /**
+     * `nonce=""` is not the same thing as no nonce: it fails a strict policy just
+     * as hard while looking like the feature works.
+     */
+    private function usable(mixed $nonce): ?string
+    {
         return is_string($nonce) && $nonce !== '' ? $nonce : null;
     }
 }

--- a/src/Support/ConfigMerger.php
+++ b/src/Support/ConfigMerger.php
@@ -55,7 +55,7 @@ final class ConfigMerger
     /**
      * A list is a value, not a structure to merge into.
      *
-     * `array_is_list([])` is true, which is the behaviour we want: an empty array
+     * `array_is_list([])` is true, which is the behavior we want: an empty array
      * the host published is an explicit "nothing here", and merging the package's
      * entries back into it would undo that choice.
      *

--- a/src/Support/MagicLinkConfig.php
+++ b/src/Support/MagicLinkConfig.php
@@ -283,7 +283,7 @@ final readonly class MagicLinkConfig
     }
 
     /**
-     * The built-in invalid-link strategy. Any value that is not a recognised
+     * The built-in invalid-link strategy. Any value that is not a recognized
      * strategy (including a custom responder class-string, handled separately)
      * falls back to the enumeration-safe redirect.
      *


### PR DESCRIPTION

### Fixed

- **The CSP nonce is found again.** `AutoScriptNonce` looked for a global `csp_nonce()`
  function. That function was introduced in spatie/laravel-csp 2.10.3 and does not exist in
  **any** 3.x release — every 3.x version publishes `autoload.psr-4` and no `autoload.files`,
  so it cannot define a global function at all. Detection therefore returned `null` for every
  application on the current series, the resend countdown's inline script shipped with no
  nonce, and a strict policy blocked it **silently** — the countdown never ran and the button
  stayed live, so a reader who clicked too early met a rejection instead of a visible wait.

  It now reads the `csp-nonce` container binding that package actually registers — the same
  one its own `@cspNonce` directive reads — and keeps the function as a fallback for
  applications that define one themselves. Both are probed by name, so this package still
  references none of that package's symbols and stays installable without it.

  Reported independently by four consuming applications, which is what a failure with no error
  message costs.

- **The WireKit screens can be served under a strict policy at all.** The same nonce now
  reaches three more tags that a strict policy rejects just as hard: the WireKit layout's
  inline `<style>` block — which was this package's own, and had never carried one — and the
  `<link>` and `<script>` WireKit itself writes, both of which accept a nonce as of WireKit
  2.24.0. Under a policy built on `'strict-dynamic'` the nonce is the only thing that grants a
  tag, so before this the screen rendered unstyled with nothing in the logs.

- **The WireKit layout emitted its two script tags in the wrong order.** `@wirekitScripts`
  registers WireKit's Alpine plugins on the `alpine:init` event and `@livewireScripts` is what
  boots Alpine, so WireKit has to come first — WireKit's own installer writes exactly that order
  when it generates a layout. This layout had them reversed, which can cost the one-time-code
  field its auto-advance and its paste distribution while the field still accepts typing one box
  at a time. Nothing caught it because the browser suite asserts the screens render *styled*, and
  styling is CSS; a missed plugin registration is invisible to it. A rendering guard now pins the
  order.

- US spelling on the published surface. Eight British spellings had accumulated across four
  source files, a Blade view and this changelog.

### Changed

- **The one-time-code screen renders the boxed field for every alphabet.** WireKit's
  `otp-input` used to accept digits only and enforced it four ways, so the shipped default
  alphabet — `ABCDEFGHJKMNPQRSTUVWXYZ23456789`, mostly letters — could not be typed into it:
  every keystroke was discarded and the boxes stayed empty. This package worked around that by
  rendering a single monospace field whenever the alphabet contained letters. WireKit 2.24.0
  added an `alphabet` prop that derives the typing filter, the paste filter, the keyboard hint
  and the validation pattern from one value, so the workaround is gone and the boxed field is
  back for everyone. A single-case alphabet is now matched case-insensitively too, so a code
  typed in lowercase is accepted rather than silently refused.

  **If you published `resources/views/vendor/email-magic-link/wirekit/`, republish it** to pick
  this up. Nothing else changes: the plain Blade screens use a single field either way, and the
  flow, routes and validation are untouched.

- **A host that cannot grant `'unsafe-eval'` no longer has to give up the WireKit look.**
  Setting WireKit's own `wirekit.scripts.bundle` to `'csp'` serves a build made against Alpine's
  CSP distribution. The documentation used to say the only option was `ui.mode = 'blade'`; it
  now names both.

### Changed — development only

Nothing in this section changes what the package does at runtime. It is recorded because
`composer.json` and `CONTRIBUTING.md` are part of the published package, so a reader of the
public repository sees the difference.

- **The development toolchain moved to Pest 5**, together with its plugin set (browser,
  Laravel, type-coverage, plus the PHPStan extension, the Rector set, the agent helper and
  the evals plugin). The published requirement is unchanged and still `php: ^8.4` — on
  8.4.0 the runtime tree resolves to the Symfony 8.0 line and installs cleanly. **Working
  on the package now needs PHP 8.4.1 or newer**, because the test toolchain pulls Symfony
  8.1, which requires it. `CONTRIBUTING.md` says so, and names the confusing symptom: on
  exactly 8.4.0 `composer install` fails citing `symfony/process`, never Pest.
- `composer.json` gains a `test:evals` script and drops the finite `process-timeout` in
  favour of `0`. Both are development-side only; no runtime dependency, autoload entry or
  published default moved.
