### PR TITLE
Release v0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.1] - 2026-08-04
+
+### Fixed
+
+- **The CSP story on the WireKit screens ended one line early.** The layout resolved a
+  nonce and handed it to `@wirekitStyles` and `@wirekitScripts` — and then called
+  `@livewireScripts` with no argument. Livewire falls back to `Vite::cspNonce()` when
+  it is called bare, which is a **different source** than this package's `ScriptNonce`
+  contract, so an application that resolves its nonce through us and not through Vite
+  served a nonced WireKit tag beside a bare Livewire one.
+
+  Under a policy built on `'strict-dynamic'` the nonce is the only thing that grants a
+  tag, so that one was blocked — and a blocked script raises no error and renders no
+  message. Alpine never booted, and the screen looked like a styling bug rather than a
+  policy rejection. This is the same failure shape as the missing countdown nonce in
+  0.20.0, one layer further down.
+
+  `@livewireScripts(['nonce' => $emlNonce])` now carries it. Passing `null` is
+  byte-identical to passing nothing, so an application without a policy renders exactly
+  as before.
+
+### Changed
+
+- **The WireKit screens now state the version they actually need.** `pushery/wirekit`
+  was suggested without a floor, which read as "any 2.x will do". Two of them do not:
+  the one-time-code field needs the `alphabet` prop (WireKit 2.22) to accept a
+  non-numeric code at all, and its case-folding validation pattern (WireKit 2.26) to
+  accept that code in lower case on a page where scripting is unavailable. On an older
+  WireKit the boxed field renders a digits-only pattern and silently refuses the code
+  this package issues.
+
+- **A one-time code typed in lower case is now accepted by the browser too.** With
+  WireKit 2.26 the field's validation pattern carries both cases whenever the alphabet
+  is single-case — like the shipped default — so the lower-case normalization no longer
+  depends on the field's JavaScript running. It was previously refused by the browser's
+  own constraint validation on exactly the strict-CSP page where that JavaScript cannot
+  run. Nothing to change in your application; the documentation no longer carries the
+  restriction.
+
 ## [0.20.0] - 2026-08-03
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -39,13 +39,13 @@
         "pestphp/pest-plugin-phpstan": "^5.0",
         "pestphp/pest-plugin-rector": "^5.0",
         "pestphp/pest-plugin-type-coverage": "^5.0",
-        "pushery/wirekit": "^2.8",
+        "pushery/wirekit": "^2.26",
         "rector/rector": "^2.0",
         "spaze/phpstan-disallowed-calls": "^4.12"
     },
     "suggest": {
         "laravel/fortify": "Enables the no-bypass two-factor (TOTP) handoff: a magic-link user with confirmed 2FA completes Fortify's challenge before being logged in (^1.0).",
-        "pushery/wirekit": "Renders the sign-in screens with WireKit components when installed; the package auto-detects it and falls back to plain Blade otherwise."
+        "pushery/wirekit": "Renders the sign-in screens with WireKit components when installed; the package auto-detects it and falls back to plain Blade otherwise. The screens are developed and tested against 2.26 and up: the one-time-code field needs the alphabet prop (2.22) to accept a non-numeric code at all, and its case-folding validation pattern (2.26) to accept that code in lower case without scripting."
     },
     "autoload": {
         "psr-4": {

--- a/config/email-magic-link.php
+++ b/config/email-magic-link.php
@@ -279,7 +279,7 @@ return [
     |   1. Set mode to "blade". The plain screens carry the same flow and use no
     |      Alpine and no Livewire, so they need no exception at all. This is the
     |      reliable answer.
-    |   2. Set wirekit.scripts.bundle to "csp" (WireKit 2.24.0+) — most of the way,
+    |   2. Set wirekit.scripts.bundle to "csp" (WireKit 2.22.0+) — most of the way,
     |      not all of it. That bundle is built against Alpine's CSP distribution, so
     |      WireKit's own components stop needing "unsafe-eval". But @wirekitScripts
     |      force-injects Livewire's assets (that is how Alpine reaches a page with no

--- a/resources/views/wirekit/code.blade.php
+++ b/resources/views/wirekit/code.blade.php
@@ -29,7 +29,7 @@
                         :error="$errors->first('email')"
                     />
 
-                    {{-- One field for every alphabet, since WireKit 2.24.0 gave otp-input
+                    {{-- One field for every alphabet, since WireKit 2.22.0 gave otp-input
                          an `alphabet` prop. Until then it was digits-only and
                          enforced it in four places — typing a non-digit cleared the box,
                          pasting stripped every non-digit, inputmode was numeric and pattern

--- a/resources/views/wirekit/layout.blade.php
+++ b/resources/views/wirekit/layout.blade.php
@@ -17,7 +17,7 @@
          are injected ONLY by this directive. Without it every var(--*-wk-*)
          resolves to nothing and the components render completely unstyled.
 
-         The nonce argument arrived in WireKit 2.24.0. Under a policy
+         The nonce argument arrived in WireKit 2.22.0. Under a policy
          built on 'strict-dynamic' the nonce is the ONLY thing that grants a tag —
          same origin is not enough — so before this the WireKit screens could not
          be served under the very policy an auth page is most likely to carry. An
@@ -54,7 +54,7 @@
         }
         .eml-shell { width: 100%; max-width: 24rem; padding: 2rem; box-sizing: border-box; }
         /* Only the CENTERING is still ours. The `flex-wrap: wrap` half of this rule
-           was a workaround and is retired: WireKit 2.24.0 ships the
+           was a workaround and is retired: WireKit 2.21.1 ships the
            digit row as `flex flex-wrap gap-2`, so a long code wraps on its own.
            It does not center the wrapped remainder, and on this 24rem card an
            eight-digit code always wraps — two boxes hanging at the left edge under
@@ -78,13 +78,23 @@
          is CSS, so a missed plugin registration is invisible to it.
 
          Nonced for the same reason as the stylesheet above. A host that cannot
-         grant 'unsafe-eval' has a lever since WireKit 2.24.0 —
+         grant 'unsafe-eval' has a lever since WireKit 2.22.0 —
          `wirekit.scripts.bundle = 'csp'`, built against Alpine's CSP distribution
          — but it is only half the answer here, and the docs say which half:
          @wirekitScripts force-injects Livewire's assets so Alpine reaches a
          pure-Blade page, and Livewire compiles its own directives at runtime the
-         same way Alpine's default build does. --}}
+         same way Alpine's default build does.
+
+         BOTH tags take the nonce, and the second one is easy to forget: WireKit
+         emits its own <script>, and @livewireScripts emits Livewire's. Without an
+         argument Livewire falls back to Vite::cspNonce(), which is a DIFFERENT
+         source than this package's ScriptNonce contract — so a host that resolves
+         its nonce through us and not through Vite got a nonced WireKit tag and a
+         bare Livewire one. Under 'strict-dynamic' the nonce is the only thing that
+         grants a tag, so that one was simply blocked and Alpine never booted.
+         Passing null is byte-identical to passing nothing (`null ?? Vite::cspNonce()`
+         still applies), so a host without a policy renders exactly as before. --}}
     @wirekitScripts($emlNonce)
-    @livewireScripts
+    @livewireScripts(['nonce' => $emlNonce])
 </body>
 </html>


### PR DESCRIPTION

### Fixed

- **The CSP story on the WireKit screens ended one line early.** The layout resolved a
  nonce and handed it to `@wirekitStyles` and `@wirekitScripts` — and then called
  `@livewireScripts` with no argument. Livewire falls back to `Vite::cspNonce()` when
  it is called bare, which is a **different source** than this package's `ScriptNonce`
  contract, so an application that resolves its nonce through us and not through Vite
  served a nonced WireKit tag beside a bare Livewire one.

  Under a policy built on `'strict-dynamic'` the nonce is the only thing that grants a
  tag, so that one was blocked — and a blocked script raises no error and renders no
  message. Alpine never booted, and the screen looked like a styling bug rather than a
  policy rejection. This is the same failure shape as the missing countdown nonce in
  0.20.0, one layer further down.

  `@livewireScripts(['nonce' => $emlNonce])` now carries it. Passing `null` is
  byte-identical to passing nothing, so an application without a policy renders exactly
  as before.

### Changed

- **The WireKit screens now state the version they actually need.** `pushery/wirekit`
  was suggested without a floor, which read as "any 2.x will do". Two of them do not:
  the one-time-code field needs the `alphabet` prop (WireKit 2.22) to accept a
  non-numeric code at all, and its case-folding validation pattern (WireKit 2.26) to
  accept that code in lower case on a page where scripting is unavailable. On an older
  WireKit the boxed field renders a digits-only pattern and silently refuses the code
  this package issues.

- **A one-time code typed in lower case is now accepted by the browser too.** With
  WireKit 2.26 the field's validation pattern carries both cases whenever the alphabet
  is single-case — like the shipped default — so the lower-case normalization no longer
  depends on the field's JavaScript running. It was previously refused by the browser's
  own constraint validation on exactly the strict-CSP page where that JavaScript cannot
  run. Nothing to change in your application; the documentation no longer carries the
  restriction.
