### PR TITLE
Release v0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.2] - 2026-08-18
+
+### Changed
+
+- **Development only — nothing changes for an application that installs this package.**
+  The `test:coverage`, `mutate` and `mutate:detect` composer scripts now run through
+  `@php -d pcov.directory=.`.
+
+  pcov collects coverage only within its own directory scope, and with that scope unset it
+  reaches neither `config/` nor `database/`. Both therefore reported 0.0% while the suite
+  had been widened to certify everything the package ships; with the scope set they report
+  100%. The two halves only work together, which is why the scripts moved with it.
+
+  These scripts are run by this package's own contributors, never by the applications that
+  require it, so upgrading from 0.20.1 is a no-op at runtime. Everything else on this
+  release line is tests, continuous-integration lanes and tooling, none of which ship.
+
 ## [0.20.1] - 2026-08-04
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     },
     "scripts": {
         "test": "pest",
-        "test:coverage": "pest --coverage --min=100",
+        "test:coverage": "@php -d pcov.directory=. vendor/bin/pest --coverage --min=100",
         "test:type-coverage": "pest --type-coverage --min=100",
         "test:browser": "pest tests/Browser tests/BrowserFortify tests/BrowserWireKit",
         "test:browser:wirekit": "pest tests/BrowserWireKit",
@@ -74,8 +74,8 @@
         "format:test": "pint --test",
         "rector": "rector process",
         "rector:test": "rector process --dry-run",
-        "mutate": "pest --mutate --everything --covered-only --min=85",
-        "mutate:detect": "pest --mutate --everything --covered-only --parallel --processes=4 --min=85",
+        "mutate": "@php -d pcov.directory=. vendor/bin/pest --mutate --everything --covered-only --min=85",
+        "mutate:detect": "@php -d pcov.directory=. vendor/bin/pest --mutate --everything --covered-only --parallel --processes=4 --min=85",
         "qa": [
             "@format:test",
             "@rector:test",


### PR DESCRIPTION

### Changed

- **Development only — nothing changes for an application that installs this package.**
  The `test:coverage`, `mutate` and `mutate:detect` composer scripts now run through
  `@php -d pcov.directory=.`.

  pcov collects coverage only within its own directory scope, and with that scope unset it
  reaches neither `config/` nor `database/`. Both therefore reported 0.0% while the suite
  had been widened to certify everything the package ships; with the scope set they report
  100%. The two halves only work together, which is why the scripts moved with it.

  These scripts are run by this package's own contributors, never by the applications that
  require it, so upgrading from 0.20.1 is a no-op at runtime. Everything else on this
  release line is tests, continuous-integration lanes and tooling, none of which ship.
