### PR TITLE
Release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,108 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - 2026-08-21
+
+### Added
+
+- **Invitation tokens — the storage half.** A magic link signs in somebody who already
+  exists; an invitation puts an account into service for an address that may have no
+  account at all. The two cannot share a table: every sign-in row is bound to an indexed,
+  NOT NULL `user_id`, and widening that column would mean altering a populated table in
+  every application that already installed this package.
+
+  So invitations get their own table, `email_magic_link_invitations`, with their own store
+  behind the `EmailMagicLink\Contracts\InvitationStore` contract. The separation also
+  removes a filter someone could forget: the sign-in store narrows on `channel = 'link'`,
+  and here there is no shared table to narrow, so an invitation token cannot reach the
+  sign-in path even in principle.
+
+  What the store guarantees: the plaintext is never stored, only a keyed hash; issuing
+  again supersedes the previous invitation for the same address and guard, so re-inviting
+  never leaves two working links behind; looking at an invitation consumes nothing; and
+  claiming one is a single conditional UPDATE, so two concurrent claims cannot both
+  succeed.
+
+  The `EmailMagicLink\Contracts\InvitationIssuer` contract mints one and hands back the
+  signed URL, and `EmailMagicLink\Contracts\InvitationHandler` is where you say what
+  accepting one MEANS — setting a password, creating membership, granting the roles the
+  inviter chose. Return an authenticatable from it and the package signs that user in
+  through the same path a magic link uses; return null and the invitation is accepted
+  without a session.
+
+  Turning invitations on requires both a handler and an acceptance view, and the package
+  refuses to boot without them rather than failing at the moment an invited person clicks
+  their link. No acceptance screen ships with it: one carrying a password field would put
+  credential handling inside a package that deliberately handles none.
+
+  `email-magic-link:purge` clears settled invitations along with expired tokens, so there
+  is no second command to schedule. The line only appears when invitations are on.
+
+  Two routes carry the acceptance, and the package owns both. The GET is inert — it
+  verifies the signature, checks the invitation, and only then renders your view — so an
+  email security scanner following the link cannot burn it, and a dead invitation is
+  refused *before* the recipient is asked for anything. Only the POST spends it, and it
+  runs the claim and your handler in one transaction: if your handler throws, the
+  acceptance rolls back and the link still works.
+
+  Every dead invitation gets the same answer, byte for byte: unknown, expired, already
+  accepted, revoked, tampered signature. The reason reaches your application through the
+  `InvitationRejected` event and goes nowhere else — anything more specific in the
+  response would answer "was this ever a real link".
+
+  The `invitations` config block defaults to `enabled => false`, so nothing changes for an
+  existing installation.
+
+### Fixed
+
+- **A magic link could be reported as unknown on a deployment with a read connection.**
+  `claimLink()` now runs in a transaction, so every statement it issues uses the write
+  connection.
+
+  `Connection::getReadPdo()` returns the read connection unless a transaction is open,
+  `sticky` is set after an earlier write, or the application forced read-on-write. Claiming
+  a link satisfied none of those — it is usually the first database work of the request — so
+  all four of its statements went to the replica: both lookups, the failure classification,
+  and, on PostgreSQL, the atomic claim itself, which is the one driver that reaches
+  `select()` rather than `update()`.
+
+  The lookups are the quieter half and the likelier one to be seen: a link issued moments
+  ago may not have replicated yet, so a valid link is rejected as unknown — intermittently,
+  and only under replication lag. One-time codes were never affected; `claimCode()` has
+  always run in a transaction.
+
+  Nothing changes for a single-connection deployment, which is the default.
+
+- **An application that sets `Date::use(CarbonImmutable::class)` could not mint at all.**
+  `issueLink()` and `issueCode()` are now typed against `Carbon\CarbonInterface`, as is
+  `MagicLinkToken::isExpired()`.
+
+  The reach was wider than the signatures suggest. Eloquent's `datetime` cast resolves
+  through the `Date` facade on every return path, so under that setting `$token->expires_at`
+  is itself a `CarbonImmutable` — and this package fed exactly that value into `IssuedLink`
+  and `IssuedCode`, which required the mutable `Illuminate\Support\Carbon`. The `TypeError`
+  was therefore raised inside the package on a call that passes no date at all, not at the
+  edge where a caller hands one in. Both entry points were unusable, not merely awkward.
+
+  No class type could ever have covered both cases: `CarbonImmutable` does not extend
+  `Illuminate\Support\Carbon`, and the two branches part further down still, at `DateTime`
+  and `DateTimeImmutable`. `CarbonInterface` is the only surface that spans them, and both
+  implement it.
+
+  **What you get back has not changed.** Without `Date::use()` these values are the mutable
+  `Illuminate\Support\Carbon` they have always been; a test pins that alongside the
+  immutable case.
+
+  Two consequences worth knowing before you upgrade:
+
+  - **Type your own parameters against `CarbonInterface`.** Runtime behavior is unchanged,
+    but code that passes `IssuedLink::$expiresAt` into a parameter typed as
+    `Illuminate\Support\Carbon` will be flagged by your own static analysis, because the
+    property is now declared wider than that.
+  - **If you extend `MagicLinkToken` and override `isExpired()`**, widen your parameter to
+    `?CarbonInterface` in the same upgrade. PHP forbids narrowing an inherited parameter, so
+    an override still typed `?Carbon` is a fatal error at class-load time.
+
 ## [0.20.2] - 2026-08-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,12 +6,19 @@
 
 # Email Magic Link for Laravel
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/pushery/email-magic-link-for-laravel.svg)](https://packagist.org/packages/pushery/email-magic-link-for-laravel)
+[![Latest Version](https://img.shields.io/packagist/v/pushery/email-magic-link-for-laravel.svg)](https://packagist.org/packages/pushery/email-magic-link-for-laravel)
 [![PHP Version](https://img.shields.io/packagist/dependency-v/pushery/email-magic-link-for-laravel/php.svg)](https://packagist.org/packages/pushery/email-magic-link-for-laravel)
-[![Laravel Version](https://badge.laravel.cloud/badge/pushery/email-magic-link-for-laravel)](https://packagist.org/packages/pushery/email-magic-link-for-laravel)
-[![PHPStan](https://img.shields.io/badge/PHPStan-max-brightgreen.svg)](https://phpstan.org/)
+[![Laravel Versions](https://badge.laravel.cloud/badge/pushery/email-magic-link-for-laravel?style=flat)](https://packagist.org/packages/pushery/email-magic-link-for-laravel)
+[![License](https://img.shields.io/packagist/l/pushery/email-magic-link-for-laravel.svg)](LICENSE)
+
+[![Tests](https://img.shields.io/badge/tests-Pest%205-8BC34A.svg)](https://pestphp.com)
+![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen.svg)
+![Type Coverage](https://img.shields.io/badge/types-100%25-brightgreen.svg)
+[![PHPStan](https://img.shields.io/badge/PHPStan-max-blue.svg)](https://phpstan.org)
 [![Code Style](https://img.shields.io/badge/code%20style-pint-orange.svg)](https://laravel.com/docs/pint)
-[![License](https://img.shields.io/packagist/l/pushery/email-magic-link-for-laravel.svg)](https://packagist.org/packages/pushery/email-magic-link-for-laravel)
+
+![Databases](https://img.shields.io/badge/tested%20on-PostgreSQL%20%2B%20MySQL-336791.svg)
+![Mutation](https://img.shields.io/badge/mutation-%E2%89%A585%25-blueviolet.svg)
 
 Passwordless email authentication for Laravel — magic links and one-time codes — that works **standalone** or alongside **Laravel Fortify**.
 
@@ -46,6 +53,7 @@ Requires PHP `^8.4` and Laravel `^13.0`. Laravel Fortify (`^1.0`) is optional an
 - **Bounded multi-use links** — hand out a link redeemable N times, with the counter decremented in the same conditional `UPDATE` that consumes it, so concurrent redemptions can never exceed the limit.
 - **Passphrase-gated links** — require a shared secret, delivered out of band, before a high-value link is consumed.
 - **A resend guard** — an escalating cooldown plus a rolling hourly cap, so a repeatedly clicked "send again" cannot flood an inbox. Reusable for your own endpoints.
+- **Invitations** — the other half of the story. A magic link can only sign in somebody who already exists; an invitation puts an account *into service* for an address that has none yet. The package issues the token, supersedes the previous one when you re-invite, refuses every dead one identically, and spends it exactly once — your application decides what accepting one means.
 - **A JSON contract** — stable statuses and error codes for first-party SPA and mobile clients.
 - **Multiple guards** — sign in to an `admin` guard alongside `web`, on an allowlist that keeps guards un-enumerable.
 - **Eleven bundled locales** — English, German, Spanish, French, Italian, Dutch and Portuguese, plus the `en-GB`, `en-US`, `pt-PT` and `pt-BR` regional variants.

--- a/config/email-magic-link.php
+++ b/config/email-magic-link.php
@@ -82,6 +82,12 @@ return [
     | guardrail enforces. The default alphabet omits visually ambiguous
     | characters (0/O, 1/I/L) for readability.
     |
+    | Case handling follows the alphabet. One that writes a single case accepts
+    | either case on submission and folds toward the one it mints, so a reader may
+    | type an all-uppercase code in lowercase. One that writes BOTH cases is case
+    | sensitive: there `a` and `A` are distinct characters that are both minted,
+    | and folding would make valid codes unredeemable.
+    |
     */
 
     'code_length' => 8,
@@ -164,8 +170,12 @@ return [
     | Notification
     |--------------------------------------------------------------------------
     |
-    | The notification used to deliver the link or code. Swap it for your own
-    | to control branding, channels, and copy.
+    | The notification used to deliver the link or code. To control branding,
+    | channels, and copy, point this at a class that EXTENDS MagicLinkNotification.
+    |
+    | It is not a contract, and a class that does not extend it is ignored rather
+    | than rejected: the package falls back to the bundled notification, so mail
+    | keeps arriving and the branding never changes.
     |
     */
 
@@ -325,9 +335,15 @@ return [
     | Rate limiting
     |--------------------------------------------------------------------------
     |
-    | Named limiters applied to the request and consume endpoints. Override them
-    | from your application with RateLimiter::for() using the same names. The
-    | "limits" defaults below are used by the bundled limiter definitions.
+    | Named limiters applied to the package's write endpoints. Override them from
+    | your application with RateLimiter::for() using the same names. The "limits"
+    | defaults below are used by the bundled limiter definitions.
+    |
+    | "request" covers ONE route (POST magic-link). "consume" covers FOUR, which
+    | therefore share one budget: POST magic-link/verify/{token}, POST
+    | magic-link/code, and both invitation routes -- including the GET that only
+    | DISPLAYS an invitation, throttled deliberately because the token in its path
+    | is guessable-in-principle and the page confirms whether it exists.
     |
     */
 
@@ -389,6 +405,50 @@ return [
     'prune' => [
         'schedule' => false,
         'frequency' => 'daily',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Invitations
+    |--------------------------------------------------------------------------
+    |
+    | A magic link signs in somebody who already exists. An invitation does the
+    | opposite: it puts an account INTO SERVICE for an address that may have no
+    | account at all -- setting a password, confirming the address, making someone a
+    | member with roles decided in advance by whoever invited them.
+    |
+    | The package owns the token: it issues one, supersedes the previous one when you
+    | re-invite, rejects an unknown, expired, accepted or revoked one identically, and
+    | spends it exactly once. It does NOT own what acceptance means. Setting a
+    | password, creating membership and granting roles are your domain, and they reach
+    | you through "handler" -- a class implementing EmailMagicLink\Contracts\
+    | InvitationHandler. Return an authenticatable from it and the package signs that
+    | user in through the same path a magic link uses, including the Fortify two-factor
+    | handoff; return null and the invitation is accepted without a session.
+    |
+    | "view" is the name of YOUR acceptance screen. No screen ships with the package:
+    | one that carried a password field would put credential handling inside a package
+    | that deliberately handles none. The package renders your view only after the
+    | token has already been checked, so a dead invitation is refused before the
+    | recipient is asked for anything.
+    |
+    | Off by default. When you turn it on, "handler" and "view" are both required and
+    | the package refuses to boot without them rather than failing at the first click.
+    |
+    | "retain_accepted_days" is how long accepted and revoked rows survive the purge.
+    | They carry the invited address in the clear, so this is a retention decision:
+    | 0 deletes them as soon as they settle and keeps no audit trail.
+    |
+    */
+
+    'invitations' => [
+        'enabled' => env('EMAIL_MAGIC_LINK_INVITATIONS_ENABLED', false),
+        'ttl' => (int) env('EMAIL_MAGIC_LINK_INVITATION_TTL', 604800),
+        'store' => null,
+        'handler' => null,
+        'view' => null,
+        'redirect_to' => '/',
+        'retain_accepted_days' => 30,
     ],
 
     'resend' => [

--- a/database/migrations/0001_01_01_000003_create_email_magic_link_invitations_table.php
+++ b/database/migrations/0001_01_01_000003_create_email_magic_link_invitations_table.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // A separate table rather than a third channel on magic_link_tokens, and the
+        // reason is the addressee: an invitation is issued to an EMAIL, for someone who
+        // may have no account at all, while every row over there is bound to a user_id
+        // that is indexed and NOT NULL. Widening that column would mean altering a
+        // populated, indexed table in every application that already adopted the package.
+        //
+        // The separation also removes a filter someone could forget. The login store
+        // narrows on `channel = 'link'`; here there is no shared table to narrow, so an
+        // invitation token cannot reach the sign-in path even in principle.
+        Schema::create('email_magic_link_invitations', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+
+            $table->string('email');
+            $table->string('guard');
+
+            // Keyed hash of the secret; the raw token exists only in the message that
+            // carries it. UNIQUE rather than merely indexed, unlike magic_link_tokens: a
+            // collision here should be a write error, never a silent wrong match.
+            $table->string('token_hash', 64)->unique();
+
+            // Whatever the inviting side decided in advance -- roles, a team, a plan.
+            // The package stores and returns it; it never interprets it.
+            $table->json('context')->nullable();
+
+            $table->string('invited_by')->nullable();
+
+            $table->timestamp('expires_at')->index();
+            $table->timestamp('accepted_at')->nullable();
+            $table->timestamp('revoked_at')->nullable();
+
+            $table->timestamps();
+
+            // Supersession and revocation both look up by exactly this pair. Two
+            // 255-character utf8mb4 columns index to 2040 bytes, inside InnoDB's
+            // 3072-byte limit, so this needs no prefix length.
+            $table->index(['email', 'guard']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('email_magic_link_invitations');
+    }
+};

--- a/lang/de/messages.php
+++ b/lang/de/messages.php
@@ -38,6 +38,7 @@ return [
     'status_link_sent' => 'Wenn ein Konto zu dieser E-Mail-Adresse passt, haben wir einen Anmeldelink gesendet.',
     'status_code_sent' => 'Wenn ein Konto zu dieser E-Mail-Adresse passt, haben wir einen Anmeldecode gesendet.',
     'consume_failed' => 'Diese Anmeldeanfrage ist ungültig oder abgelaufen. Bitte fordere eine neue an.',
+    'invitation_failed' => 'Diese Einladung ist ungültig oder abgelaufen. Bitte die Person, die dich eingeladen hat, um eine neue.',
     'captcha_failed' => 'Die Sicherheitsprüfung ist fehlgeschlagen. Bitte versuche es erneut.',
     'resend_throttled' => 'Bitte warte :seconds Sekunden, bevor du eine weitere Anmelde-E-Mail anforderst.',
     'resend_countdown_label' => 'Wartezeit, bis du eine weitere E-Mail anfordern kannst',

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -38,6 +38,7 @@ return [
     'status_link_sent' => 'If an account matches that email, we have sent a sign-in link.',
     'status_code_sent' => 'If an account matches that email, we have sent a sign-in code.',
     'consume_failed' => 'This sign-in request is invalid or has expired. Please request a new one.',
+    'invitation_failed' => 'This invitation is invalid or has expired. Ask whoever invited you for a new one.',
     'captcha_failed' => 'The verification challenge failed. Please try again.',
     'resend_throttled' => 'Please wait :seconds seconds before requesting another sign-in email.',
     'resend_countdown_label' => 'Wait time before you can request another email',

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -38,6 +38,7 @@ return [
     'status_link_sent' => 'Si una cuenta coincide con ese correo, te hemos enviado un enlace de acceso.',
     'status_code_sent' => 'Si una cuenta coincide con ese correo, te hemos enviado un código de acceso.',
     'consume_failed' => 'Esta solicitud de acceso no es válida o ha caducado. Solicita una nueva.',
+    'invitation_failed' => 'Esta invitación no es válida o ha caducado. Pide una nueva a quien te invitó.',
     'captcha_failed' => 'La verificación ha fallado. Inténtalo de nuevo.',
     'resend_throttled' => 'Espera :seconds segundos antes de solicitar otro correo de acceso.',
     'resend_countdown_label' => 'Tiempo de espera antes de poder solicitar otro correo',

--- a/lang/fr/messages.php
+++ b/lang/fr/messages.php
@@ -38,6 +38,7 @@ return [
     'status_link_sent' => 'Si un compte correspond à cette adresse e-mail, nous vous avons envoyé un lien de connexion.',
     'status_code_sent' => 'Si un compte correspond à cette adresse e-mail, nous vous avons envoyé un code de connexion.',
     'consume_failed' => 'Cette demande de connexion est invalide ou a expiré. Veuillez en demander une nouvelle.',
+    'invitation_failed' => 'Cette invitation n\'est pas valide ou a expiré. Demandez-en une nouvelle à la personne qui vous a invité.',
     'captcha_failed' => 'La vérification a échoué. Veuillez réessayer.',
     'resend_throttled' => 'Veuillez patienter :seconds secondes avant de demander un nouvel e-mail de connexion.',
     'resend_countdown_label' => 'Temps d’attente avant de pouvoir demander un nouvel e-mail',

--- a/lang/it/messages.php
+++ b/lang/it/messages.php
@@ -38,6 +38,7 @@ return [
     'status_link_sent' => 'Se un account corrisponde a quell’email, ti abbiamo inviato un link di accesso.',
     'status_code_sent' => 'Se un account corrisponde a quell’email, ti abbiamo inviato un codice di accesso.',
     'consume_failed' => 'Questa richiesta di accesso non è valida o è scaduta. Richiedine una nuova.',
+    'invitation_failed' => 'Questo invito non è valido o è scaduto. Chiedi un nuovo invito a chi ti ha invitato.',
     'captcha_failed' => 'La verifica non è riuscita. Riprova.',
     'resend_throttled' => 'Attendi :seconds secondi prima di richiedere un’altra email di accesso.',
     'resend_countdown_label' => 'Tempo di attesa prima di poter richiedere un’altra email',

--- a/lang/nl/messages.php
+++ b/lang/nl/messages.php
@@ -38,6 +38,7 @@ return [
     'status_link_sent' => 'Als een account overeenkomt met dat e-mailadres, hebben we een inloglink gestuurd.',
     'status_code_sent' => 'Als een account overeenkomt met dat e-mailadres, hebben we een inlogcode gestuurd.',
     'consume_failed' => 'Deze inlogaanvraag is ongeldig of verlopen. Vraag een nieuwe aan.',
+    'invitation_failed' => 'Deze uitnodiging is ongeldig of verlopen. Vraag degene die je uitnodigde om een nieuwe.',
     'captcha_failed' => 'De verificatie is mislukt. Probeer het opnieuw.',
     'resend_throttled' => 'Wacht :seconds seconden voordat je een nieuwe inlogmail aanvraagt.',
     'resend_countdown_label' => 'Wachttijd voordat je een nieuwe e-mail kunt aanvragen',

--- a/lang/pt-PT/messages.php
+++ b/lang/pt-PT/messages.php
@@ -48,6 +48,7 @@ return [
     'status_link_sent' => 'Se existir uma conta com esse e-mail, enviámos um link de acesso.',
     'status_code_sent' => 'Se existir uma conta com esse e-mail, enviámos um código de acesso.',
     'consume_failed' => 'Este pedido de acesso é inválido ou expirou. Solicita um novo.',
+    'invitation_failed' => 'Este convite é inválido ou expirou. Peça um novo a quem o convidou.',
     'captcha_failed' => 'A verificação falhou. Tenta novamente.',
     'resend_throttled' => 'Aguarda :seconds segundos antes de solicitares outro e-mail de acesso.',
     'resend_countdown_label' => 'Tempo de espera antes de poderes solicitar outro e-mail',

--- a/lang/pt/messages.php
+++ b/lang/pt/messages.php
@@ -38,6 +38,7 @@ return [
     'status_link_sent' => 'Se existir uma conta com esse e-mail, enviámos um link de acesso.',
     'status_code_sent' => 'Se existir uma conta com esse e-mail, enviámos um código de acesso.',
     'consume_failed' => 'Este pedido de acesso é inválido ou expirou. Solicite um novo.',
+    'invitation_failed' => 'Este convite é inválido ou expirou. Peça um novo a quem te convidou.',
     'captcha_failed' => 'A verificação falhou. Tente novamente.',
     'resend_throttled' => 'Aguarde :seconds segundos antes de solicitar outro e-mail de acesso.',
     'resend_countdown_label' => 'Tempo de espera antes de poder solicitar outro e-mail',

--- a/resources/boost/skills/email-magic-link-for-laravel/SKILL.md
+++ b/resources/boost/skills/email-magic-link-for-laravel/SKILL.md
@@ -68,7 +68,8 @@ decide the shape of the integration:
 | Key | Effect |
 |---|---|
 | `mode` | `link`, `code`, or `both` — which credential the request form issues |
-| `link_ttl` / `code_ttl` | Per-channel lifetime in seconds (default 900) |
+| `ttl` | Credential lifetime in seconds — **900**, and the only one of the three with a default |
+| `link_ttl` / `code_ttl` | Per-channel override in seconds; `null` (the default) means fall back to `ttl` |
 | `max_uses` | Bounded multi-use links; `1` is single-use |
 | `guard` / `guards` | Which auth guard to sign in to; `guards` is an allowlist |
 | `routes.*` | Prefix, middleware, and the post-login redirect |
@@ -142,26 +143,48 @@ Do not do both — that is two scheduler entries for one job.
 
 ## Examples
 
-Sign in to a second guard, with codes instead of links, behind a custom prefix:
+Sign in to a second guard, with codes instead of links, behind a custom prefix.
+**`guard` is what the request signs in to** — `guards` only widens the allowlist:
 
 ```php
 // config/email-magic-link.php
 'mode' => 'code',
-'guards' => ['admin'],
+'guard' => 'admin',
 'routes' => [
     'prefix' => 'admin/sign-in',
     'redirect_to' => '/admin',
 ],
 ```
 
-Gate a resource behind a link without creating a session — mint the link, deliver
-it yourself, and let consumption redirect to the resource:
+Reach for `guards` only when ONE installation must serve several guards and the
+request picks between them by submitting a `guard` field. An unlisted value falls
+back to `guard` silently rather than erroring, so the endpoint never reveals which
+guards exist:
+
+```php
+'guard' => 'web',
+'guards' => ['admin'],   // a request may now ask for "admin" as well
+```
+
+Deliver a link over your own channel — mint it, send it yourself, skip the
+package's request form and its notification entirely:
 
 ```php
 $link = EmailMagicLink::issueLink($user, maxUses: 3, passphrase: $sharedSecret);
 
 Mail::to($user)->send(new InvoiceReady($link->url, $link->expiresInMinutes));
 ```
+
+**What that link does is sign the user in, and only that.** `$link->url` points at
+the package's confirmation page — an inert signed `GET` that spends nothing. The
+token is consumed when the recipient submits that page, and they then land on
+`routes.redirect_to`, exactly as they would coming through the request form. So:
+
+- it is **not** a session-less channel — a consumed link authenticates a session;
+- it does **not** redirect to a resource of your choosing — point `redirect_to` at
+  the resource, or send the recipient onward once they arrive authenticated.
+
+Deliver `$link->url` verbatim, and never prefetch it.
 
 Swap the resolution of an email address to a user (multi-tenant lookups, soft
 deletes, custom columns) by binding the contract:
@@ -171,9 +194,14 @@ deletes, custom columns) by binding the contract:
 'user_lookup' => App\Auth\TenantUserLookup::class,
 ```
 
-The same pattern applies to `token_store`, `captcha`, `notification` and
-`invalid_response.via` — each takes the class-string of a published contract and
-falls back to a bundled default.
+The same pattern applies to `token_store`, `captcha` and `invalid_response.via`
+— each takes the class-string of a published contract under
+`EmailMagicLink\\Contracts` and falls back to a bundled default.
+
+`notification` is the odd one out and is **not** a contract: it takes a class that
+**extends `MagicLinkNotification`**. Anything else is ignored — the package falls
+back to the bundled notification without raising, so a wrong class-string looks
+like it worked.
 
 ## Anti-Patterns
 

--- a/routes/email-magic-link.php
+++ b/routes/email-magic-link.php
@@ -2,11 +2,13 @@
 
 declare(strict_types=1);
 
+use EmailMagicLink\Http\Controllers\AcceptInvitationController;
 use EmailMagicLink\Http\Controllers\ConfirmMagicLinkController;
 use EmailMagicLink\Http\Controllers\ConsumeCodeController;
 use EmailMagicLink\Http\Controllers\ConsumeMagicLinkController;
 use EmailMagicLink\Http\Controllers\SendMagicLinkController;
 use EmailMagicLink\Http\Controllers\ShowCodeFormController;
+use EmailMagicLink\Http\Controllers\ShowInvitationController;
 use EmailMagicLink\Http\Controllers\ShowRequestFormController;
 use EmailMagicLink\Support\MagicLinkConfig;
 use Illuminate\Support\Facades\Route;
@@ -46,3 +48,23 @@ Route::get('magic-link/code', ShowCodeFormController::class)
 Route::post('magic-link/code', ConsumeCodeController::class)
     ->middleware("throttle:{$consumeLimiter}")
     ->name('email-magic-link.code.consume');
+
+// Invitations are a separate channel and register only when the host turns them on:
+// both routes are useless without an acceptance view and a handler, and the boot guard
+// has already refused to start if those are missing.
+if ($config->invitationsEnabled()) {
+    // Deliberately NOT behind `signed`. That middleware answers an expired signature with
+    // 403 and an unknown token with the generic page, and those two answers are
+    // distinguishable -- at a seven-day lifetime, expiry is the ordinary case. The
+    // signature is verified inside the controller and folded into the one refusal.
+    //
+    // Inert like the sign-in confirmation: only the POST spends the invitation, so a
+    // scanner following the link cannot burn it.
+    Route::get('magic-link/invitation/{token}', ShowInvitationController::class)
+        ->middleware("throttle:{$consumeLimiter}")
+        ->name('email-magic-link.invitation.show');
+
+    Route::post('magic-link/invitation/{token}', AcceptInvitationController::class)
+        ->middleware("throttle:{$consumeLimiter}")
+        ->name('email-magic-link.invitation.accept');
+}

--- a/src/Console/Commands/DoctorCommand.php
+++ b/src/Console/Commands/DoctorCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Console\Commands;
 
+use EmailMagicLink\Contracts\ScriptNonce;
+use EmailMagicLink\Support\AutoScriptNonce;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
@@ -38,6 +40,10 @@ final class DoctorCommand extends Command
         if (! is_file($publishedPath)) {
             $this->info('No published config — this application uses the package defaults, so nothing can drift.');
             $this->line('  Publish one with: php artisan vendor:publish --tag=email-magic-link-config');
+
+            // Also on this path: a host with no published config has the same CSP
+            // question, and this branch returns before the report below.
+            $this->reportScriptNonce($config);
 
             return self::SUCCESS;
         }
@@ -82,10 +88,79 @@ final class DoctorCommand extends Command
             $this->info('Your published config matches this version key for key.');
         }
 
+        $this->reportScriptNonce($config);
+
         // Reporting, never gating: this runs in a deploy pipeline and a drifted
         // config is a thing to read, not a thing to fail a release on. `unknown`
         // in particular is often a deliberate leftover during a staged upgrade.
         return self::SUCCESS;
+    }
+
+    /**
+     * Report WHERE a CSP nonce would come from — never what it is.
+     *
+     * `AutoScriptNonce` deliberately falls back to null instead of throwing, because
+     * an exception would take down the sign-in screen over a progressive
+     * enhancement. The price is that a nonce which cannot be resolved produces NO
+     * signal at all: the script ships without the attribute, a strict policy blocks
+     * it, and the only symptom is a resend button that never counts down. That took
+     * four separate consumers to notice.
+     *
+     * A log warning would be the wrong instrument — most hosts have no policy at
+     * all, so it would fire almost always, get filtered, and take the one meaningful
+     * warning with it. This command is already the place someone reads when they
+     * have a question.
+     *
+     * ⚠️ It reports the SOURCE, not the value, and that is a correctness point
+     * rather than caution. The nonce is scoped per request; a console command either
+     * cannot resolve the binding at all or resolves one that no response will ever
+     * carry. Printing it would show a value that is real and useless. Whether the
+     * SOURCE exists is the same question in the console as in a request, so that is
+     * what gets answered.
+     */
+    private function reportScriptNonce(Repository $config): void
+    {
+        $this->newLine();
+
+        $custom = $config->get('email-magic-link.ui.script_nonce');
+
+        if (is_string($custom) && is_a($custom, ScriptNonce::class, true)) {
+            $this->line("CSP nonce   custom ({$custom} via ui.script_nonce)");
+
+            return;
+        }
+
+        if (is_string($custom) && $custom !== '') {
+            // Configured but unusable: the value is ignored and the package falls
+            // back to auto-detection, which looks identical to having configured
+            // nothing. Naming it is the whole point of this command.
+            $this->line("CSP nonce   ui.script_nonce is set to \"{$custom}\", which does not implement ".ScriptNonce::class);
+            $this->line('            The setting is IGNORED and auto-detection runs instead.');
+
+            return;
+        }
+
+        $sources = [];
+
+        if ($this->laravel->bound(AutoScriptNonce::$binding)) {
+            $sources[] = 'the "'.AutoScriptNonce::$binding.'" container binding';
+        }
+
+        if (function_exists(AutoScriptNonce::$helper)) {
+            $sources[] = 'the global '.AutoScriptNonce::$helper.'() function';
+        }
+
+        if ($sources === []) {
+            $this->line('CSP nonce   no source detected — fine if this app has no policy');
+            $this->line('            Under a strict Content-Security-Policy the bundled inline script');
+            $this->line('            would be blocked, and it fails silently. See ui.script_nonce.');
+
+            return;
+        }
+
+        $this->line('CSP nonce   resolved from '.implode(', then ', $sources));
+        $this->line('            Source only: the nonce itself is per-request, so a console run');
+        $this->line('            cannot show the value a response would carry.');
     }
 
     /**

--- a/src/Console/Commands/PurgeExpiredTokensCommand.php
+++ b/src/Console/Commands/PurgeExpiredTokensCommand.php
@@ -4,26 +4,38 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Console\Commands;
 
+use EmailMagicLink\Contracts\InvitationStore;
 use EmailMagicLink\Contracts\TokenStore;
+use EmailMagicLink\Support\MagicLinkConfig;
 use Illuminate\Console\Command;
 
 /**
- * Deletes expired and consumed magic-link tokens.
+ * Deletes expired and consumed magic-link tokens — and, when invitations are
+ * switched on, expired and claimed invitations in the same run.
  *
- * Schedule it (for example daily) so the token table does not grow unbounded:
+ * Schedule it (for example daily) so neither table grows unbounded:
  * Schedule::command('email-magic-link:purge')->daily();
  */
 final class PurgeExpiredTokensCommand extends Command
 {
     protected $signature = 'email-magic-link:purge';
 
-    protected $description = 'Delete expired and consumed magic-link tokens.';
+    protected $description = 'Delete expired and consumed magic-link tokens, and invitations when they are enabled.';
 
-    public function handle(TokenStore $store): int
+    public function handle(TokenStore $store, MagicLinkConfig $config): int
     {
         $removed = $store->purge();
 
         $this->info("Purged {$removed} magic-link token(s).");
+
+        // One command for both tables rather than a second one to schedule and a second
+        // one to forget. The line only appears when invitations are switched on, so an
+        // installation that does not use them sees exactly the output it always saw.
+        if ($config->invitationsEnabled()) {
+            $invitations = $this->laravel->make(InvitationStore::class)->purge();
+
+            $this->info("Purged {$invitations} invitation(s).");
+        }
 
         return self::SUCCESS;
     }

--- a/src/Contracts/InvitationHandler.php
+++ b/src/Contracts/InvitationHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Contracts;
+
+use EmailMagicLink\Support\AcceptedInvitation;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
+
+/**
+ * What accepting an invitation MEANS in your application.
+ *
+ * This is the one seam the invitation flow has, and the package deliberately owns
+ * nothing behind it. Setting a password, creating the account, making somebody a
+ * member, granting the roles the inviter chose — all of that is your domain. A
+ * package that did it for you would have to know your user model, your password
+ * policy and your membership rules, and it would stop being an authentication
+ * building block.
+ *
+ * Return an authenticatable and the package signs that user in through the same
+ * path a magic link uses — including the Fortify two-factor handoff, if you have
+ * it. Return null and the invitation is accepted without a session, which is what
+ * you want when acceptance still has to be approved by somebody else.
+ *
+ * Runs INSIDE the transaction that spends the token: throw, and the acceptance is
+ * rolled back with it, so a half-created account cannot outlive a spent invitation.
+ * Keep the work here short for the same reason.
+ *
+ * The `context` you passed to the issuer comes back untouched. Treat it as a
+ * statement about the past, not the present: an invitation can be a week old, and
+ * whatever it names — a role, a team, a plan — may have changed or disappeared in
+ * the meantime. Validate it against current state before acting on it.
+ */
+interface InvitationHandler
+{
+    public function accept(AcceptedInvitation $invitation, Request $request): ?Authenticatable;
+}

--- a/src/Contracts/InvitationIssuer.php
+++ b/src/Contracts/InvitationIssuer.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Contracts;
+
+use EmailMagicLink\Support\IssuedInvitation;
+
+/**
+ * Issues invitations for an email address WITHOUT sending mail.
+ *
+ * The counterpart to MagicLinkIssuer, and the difference is the addressee: a magic
+ * link signs in somebody who already exists, so it is issued for a resolved user.
+ * An invitation is issued for an ADDRESS, which may have no account behind it — that
+ * is the whole point, and it is why this cannot be a method on the other contract.
+ *
+ * Deliver the returned URL over any channel you like. The raw token exists only
+ * inside that URL; nothing in the package stores or logs it.
+ */
+interface InvitationIssuer
+{
+    /**
+     * Issue an invitation, superseding any earlier unaccepted one for the same
+     * address and guard.
+     *
+     * @param  string|null  $guard  An allowed guard, or null for the default.
+     * @param  array<string, mixed>|null  $context  Whatever was decided in advance —
+     *                                              roles, a team, a plan. Stored
+     *                                              verbatim, handed back to your
+     *                                              handler on acceptance, never
+     *                                              interpreted by the package.
+     * @param  string|null  $invitedBy  Free-form identifier of whoever invited, for
+     *                                  your own audit trail.
+     * @param  string|null  $baseUrl  Build the link for this host (e.g. a tenant
+     *                                domain) instead of the app's. The signature
+     *                                binds to that host, so the link verifies only
+     *                                there.
+     */
+    public function invite(string $email, ?string $guard = null, ?array $context = null, ?string $invitedBy = null, ?string $baseUrl = null): IssuedInvitation;
+
+    /**
+     * Revoke every unaccepted invitation for the address and guard. Returns the
+     * number revoked; an already accepted invitation is left alone.
+     */
+    public function revoke(string $email, ?string $guard = null): int;
+}

--- a/src/Contracts/InvitationStore.php
+++ b/src/Contracts/InvitationStore.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Contracts;
+
+use EmailMagicLink\Support\InvitationClaimResult;
+use EmailMagicLink\Support\IssuedInvitationToken;
+
+/**
+ * Issues, stores, and atomically consumes invitation tokens.
+ *
+ * The raw secret is never persisted: only a keyed hash is stored and indexed.
+ * Consumption is a single race-free conditional claim, so two concurrent
+ * requests for the same invitation can never both succeed.
+ *
+ * An invitation is addressed to an EMAIL, not to a user. That is the difference
+ * from TokenStore, and it is the reason this contract exists: a sign-in token can
+ * only be issued for somebody who already has an account.
+ */
+interface InvitationStore
+{
+    /**
+     * Issue a fresh invitation and return the plaintext secret.
+     *
+     * Issuing supersedes any earlier unaccepted invitation for the same email and
+     * guard, so re-inviting someone never leaves two working links behind.
+     *
+     * @param  array<string, mixed>|null  $context  Whatever the inviting side decided in
+     *                                              advance. Stored verbatim and handed back
+     *                                              on acceptance; never interpreted here.
+     * @param  int|null  $ttl  Lifetime in seconds; null uses the configured default.
+     */
+    public function issue(string $email, string $guard, ?array $context = null, ?string $invitedBy = null, ?int $ttl = null): IssuedInvitationToken;
+
+    /**
+     * Look up an invitation by its plaintext token WITHOUT consuming it.
+     *
+     * Read-only by contract. It is what lets the confirmation page reject a dead
+     * invitation before asking the recipient for anything.
+     */
+    public function peek(string $token): InvitationClaimResult;
+
+    /**
+     * Atomically claim an invitation by its plaintext token.
+     */
+    public function claim(string $token): InvitationClaimResult;
+
+    /**
+     * Revoke every unaccepted invitation for the email and guard. Returns the number
+     * revoked. An already accepted invitation is left alone -- it is a record of
+     * something that happened, not an open door.
+     */
+    public function revoke(string $email, string $guard): int;
+
+    /**
+     * Delete expired invitations, and accepted or revoked ones past the configured
+     * retention window. Returns the number removed.
+     */
+    public function purge(): int;
+}

--- a/src/EmailMagicLinkServiceProvider.php
+++ b/src/EmailMagicLinkServiceProvider.php
@@ -11,20 +11,27 @@ use EmailMagicLink\Console\Commands\InstallCommand;
 use EmailMagicLink\Console\Commands\PurgeExpiredTokensCommand;
 use EmailMagicLink\Contracts\CaptchaGuard;
 use EmailMagicLink\Contracts\InvalidLinkResponder;
+use EmailMagicLink\Contracts\InvitationHandler;
+use EmailMagicLink\Contracts\InvitationIssuer;
+use EmailMagicLink\Contracts\InvitationStore;
 use EmailMagicLink\Contracts\MagicLinkAuthenticator;
 use EmailMagicLink\Contracts\MagicLinkIssuer;
 use EmailMagicLink\Contracts\ResendGuard;
 use EmailMagicLink\Contracts\ScriptNonce;
 use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Contracts\UserLookup;
+use EmailMagicLink\Exceptions\InvitationsMisconfiguredException;
 use EmailMagicLink\Http\Responses\DefaultInvalidLinkResponder;
 use EmailMagicLink\Lookups\DefaultUserLookup;
+use EmailMagicLink\Stores\DefaultInvitationStore;
 use EmailMagicLink\Stores\DefaultTokenStore;
 use EmailMagicLink\Support\AutoScriptNonce;
 use EmailMagicLink\Support\ConfigMerger;
+use EmailMagicLink\Support\DefaultInvitationIssuer;
 use EmailMagicLink\Support\DefaultMagicLinkIssuer;
 use EmailMagicLink\Support\DefaultResendGuard;
 use EmailMagicLink\Support\EntropyGuard;
+use EmailMagicLink\Support\InvitationGuard;
 use EmailMagicLink\Support\MagicLinkConfig;
 use EmailMagicLink\Support\RateLimits;
 use EmailMagicLink\Support\TokenHasher;
@@ -115,6 +122,42 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
             $app->make(AuthManager::class),
         ));
 
+        $this->app->singleton(InvitationStore::class, function (Application $app): InvitationStore {
+            $custom = $app->make(MagicLinkConfig::class)->invitationStore();
+
+            return $this->resolveContract($app, InvitationStore::class, $custom, DefaultInvitationStore::class);
+        });
+
+        $this->app->singleton(InvitationIssuer::class, fn (Application $app): InvitationIssuer => new DefaultInvitationIssuer(
+            $app->make(InvitationStore::class),
+            $app->make(MagicLinkConfig::class),
+        ));
+
+        // Resolved lazily and never defaulted. There is no sensible fallback: what
+        // accepting an invitation means is the one thing the package cannot know, so a
+        // missing handler is an error rather than a no-op. The boot guard normally
+        // catches it first; this closure is what keeps the failure honest if something
+        // resolves the contract on an installation the guard never ran on.
+        $this->app->singleton(InvitationHandler::class, function (Application $app): InvitationHandler {
+            $class = $app->make(MagicLinkConfig::class)->invitationHandler();
+
+            if ($class === null) {
+                throw InvitationsMisconfiguredException::missingHandler();
+            }
+
+            if (! class_exists($class)) {
+                throw InvitationsMisconfiguredException::handlerContract($class);
+            }
+
+            $resolved = $app->make($class);
+
+            if ($resolved instanceof InvitationHandler) {
+                return $resolved;
+            }
+
+            throw InvitationsMisconfiguredException::handlerContract($class);
+        });
+
         $this->app->singleton(ResendGuard::class, fn (Application $app): ResendGuard => new DefaultResendGuard(
             $app->make(CacheFactory::class),
             $app->make(MagicLinkConfig::class),
@@ -143,6 +186,7 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
 
         // Fail closed before anything user-facing is registered.
         new EntropyGuard($config)->validate();
+        new InvitationGuard($config)->validate();
 
         $this->registerRateLimiters($config);
         $this->registerRoutes($config);
@@ -165,6 +209,17 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
     private function registerPruneSchedule(MagicLinkConfig $config): void
     {
         if (! $config->pruneSchedule()) {
+            return;
+        }
+
+        // The config flag above answers whether the consumer WANTS the purge. This one
+        // answers whether it CAN run at all: a consumer that called ignoreMigrations()
+        // declined the tables, so the command would hit a relation that does not exist —
+        // a non-zero exit every night, and with schedule monitoring one entry in the error
+        // tracker per night, for a table it deliberately refused. Read from the flag rather
+        // than from the schema: this runs at BOOT, and asking the database there would put
+        // a query on every request to answer a question about a nightly job.
+        if (! self::$runsMigrations) {
             return;
         }
 
@@ -302,7 +357,7 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
             // application's own create_users_table, so `migrate` on a fresh app
             // tries to create a table with a foreign key to users that does not
             // exist yet. The bundled prefix is correct for auto-loading (it must
-            // sort deterministically among the package's own three) and wrong the
+            // sort deterministically among the package's own) and wrong the
             // moment the files land in the app's migrations directory.
             $this->publishesMigrations([
                 __DIR__.'/../database/migrations' => database_path('migrations'),

--- a/src/Events/InvitationAccepted.php
+++ b/src/Events/InvitationAccepted.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Events;
+
+use EmailMagicLink\Support\AcceptedInvitation;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
+
+/**
+ * An invitation was spent and the handler ran to completion.
+ *
+ * Fired AFTER the transaction commits, so a listener can rely on the acceptance
+ * having actually happened -- and so a slow listener cannot hold a database
+ * transaction open. `$user` is whatever the handler returned: null means the
+ * invitation was accepted without signing anybody in.
+ */
+final readonly class InvitationAccepted
+{
+    public function __construct(
+        public AcceptedInvitation $invitation,
+        public ?Authenticatable $user,
+        public Request $request,
+    ) {}
+}

--- a/src/Events/InvitationRejected.php
+++ b/src/Events/InvitationRejected.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Events;
+
+use EmailMagicLink\Support\ClaimFailure;
+use Illuminate\Http\Request;
+
+/**
+ * An invitation link was refused, with the reason the visitor never sees.
+ *
+ * Its own type rather than MagicLinkConsumptionFailed, and that distinction is
+ * operational: a link-following scanner touching an invitation URL is routine, and
+ * folding it into the sign-in failure event would fire whatever alerting sits on
+ * that one. These are different things happening to different people.
+ */
+final readonly class InvitationRejected
+{
+    public function __construct(
+        public ClaimFailure $reason,
+        public Request $request,
+    ) {}
+}

--- a/src/Exceptions/InvitationsDisabledException.php
+++ b/src/Exceptions/InvitationsDisabledException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown when an invitation is issued while the channel is switched off.
+ *
+ * Loud rather than silent: minting a token nobody can redeem would look like it
+ * worked, and the person holding the dead link is the one who finds out.
+ */
+final class InvitationsDisabledException extends RuntimeException
+{
+    public static function make(): self
+    {
+        return new self(
+            'Invitations are disabled. Set email-magic-link.invitations.enabled to true, '
+            .'and configure invitations.handler and invitations.view.',
+        );
+    }
+}

--- a/src/Exceptions/InvitationsMisconfiguredException.php
+++ b/src/Exceptions/InvitationsMisconfiguredException.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Exceptions;
+
+use EmailMagicLink\Contracts\InvitationHandler;
+use RuntimeException;
+
+/**
+ * Thrown at boot when invitations are on but cannot work.
+ *
+ * At boot rather than at request time, and that is the whole point: the alternative
+ * is a 500 at the moment an invited person clicks their link, which is both the
+ * worst time to find out and the hardest place to see it.
+ */
+final class InvitationsMisconfiguredException extends RuntimeException
+{
+    public static function missingHandler(): self
+    {
+        return new self(
+            'Invitations are enabled but email-magic-link.invitations.handler is not set. '
+            .'Point it at a class implementing '.InvitationHandler::class.'; it decides what '
+            .'accepting an invitation does in your application.',
+        );
+    }
+
+    public static function missingView(): self
+    {
+        return new self(
+            'Invitations are enabled but email-magic-link.invitations.view is not set. '
+            .'Point it at your acceptance screen; the package ships none, because one '
+            .'carrying a password field would put credential handling inside a package '
+            .'that handles none.',
+        );
+    }
+
+    public static function handlerContract(string $class): self
+    {
+        return new self(
+            "[{$class}] must implement [".InvitationHandler::class.'] to be used as '
+            .'email-magic-link.invitations.handler.',
+        );
+    }
+}

--- a/src/Http/Controllers/AcceptInvitationController.php
+++ b/src/Http/Controllers/AcceptInvitationController.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Controllers;
+
+use EmailMagicLink\Contracts\InvitationHandler;
+use EmailMagicLink\Contracts\InvitationStore;
+use EmailMagicLink\Contracts\MagicLinkAuthenticator;
+use EmailMagicLink\Events\InvitationAccepted;
+use EmailMagicLink\Events\InvitationRejected;
+use EmailMagicLink\Http\Controllers\Concerns\RejectsGenerically;
+use EmailMagicLink\Models\Invitation;
+use EmailMagicLink\Support\AcceptedInvitation;
+use EmailMagicLink\Support\ClaimFailure;
+use EmailMagicLink\Support\MagicLinkConfig;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Spends the invitation and hands the decision to the host.
+ *
+ * The only state-changing step of the flow, and the only one behind CSRF.
+ *
+ * The claim and the host's handler run in ONE transaction. That is what makes a
+ * thrown handler safe: a validation failure on a too-short password, or a unique
+ * constraint losing a race, rolls the acceptance back with it, and the invited
+ * person's link still works. The alternative -- spend first, create after -- turns
+ * every handler failure into a burnt invitation and a support request.
+ *
+ * Signing in happens AFTER the commit and goes through the same authenticator
+ * singleton a magic link uses, which the Fortify bridge decorates. So an invited
+ * person who already has confirmed two-factor lands in Fortify's challenge instead
+ * of being quietly signed in -- which the package gets for free precisely because
+ * the host does not call Auth::login() itself.
+ */
+final readonly class AcceptInvitationController
+{
+    use RejectsGenerically;
+
+    public function __construct(
+        private MagicLinkConfig $config,
+        private InvitationStore $store,
+    ) {}
+
+    public function __invoke(Request $request, string $token): Response
+    {
+        // The closure returns EITHER a failure OR the pair, rather than writing into
+        // captured variables and reporting success separately. With by-reference captures
+        // nothing can know the pair was set, which forced a third branch that no input can
+        // reach -- and an unreachable branch is not a hole to test, it is a shape to fix.
+        /** @var ClaimFailure|array{0: AcceptedInvitation, 1: ?Authenticatable} $outcome */
+        $outcome = (new Invitation)->getConnection()->transaction(function () use ($token, $request): ClaimFailure|array {
+            $result = $this->store->claim($token);
+
+            if (! $result->successful || ! $result->invitation instanceof Invitation) {
+                return $result->failure ?? ClaimFailure::NotFound;
+            }
+
+            $accepted = new AcceptedInvitation(
+                $result->invitation->id,
+                $result->invitation->email,
+                $result->invitation->guard,
+                $result->invitation->context,
+                $result->invitation->invited_by,
+            );
+
+            return [$accepted, app(InvitationHandler::class)->accept($accepted, $request)];
+        });
+
+        if ($outcome instanceof ClaimFailure) {
+            event(new InvitationRejected($outcome, $request));
+
+            return $this->genericRejection(
+                $request,
+                (string) __('email-magic-link::messages.invitation_failed'),
+                'email-magic-link.request.form',
+            );
+        }
+
+        [$accepted, $user] = $outcome;
+
+        event(new InvitationAccepted($accepted, $user, $request));
+
+        if (! $user instanceof Authenticatable) {
+            // The handler accepted without producing a session -- which is what you want
+            // when acceptance still needs somebody else's approval.
+            return redirect()->to($this->config->invitationRedirectTo());
+        }
+
+        return app(MagicLinkAuthenticator::class)->authenticate($request, $user, $accepted->guard, false);
+    }
+}

--- a/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
+++ b/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Http\Controllers\Concerns;
 
-use EmailMagicLink\Contracts\InvalidLinkResponder;
 use EmailMagicLink\Contracts\MagicLinkAuthenticator;
 use EmailMagicLink\Contracts\ResendGuard;
 use EmailMagicLink\Events\MagicLinkConsumptionFailed;
 use EmailMagicLink\Events\MagicLinkVerified;
 use EmailMagicLink\Models\MagicLinkToken;
 use EmailMagicLink\Support\ClaimFailure;
-use EmailMagicLink\Support\MagicLinkConfig;
 use EmailMagicLink\Support\ResendKey;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -27,7 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 trait CompletesMagicLinkLogin
 {
-    use RespondsToApiClients;
+    use RejectsGenerically;
 
     protected function completeLogin(Request $request, MagicLinkToken $token, string $failureRoute): Response
     {
@@ -78,18 +76,9 @@ trait CompletesMagicLinkLogin
     {
         event(new MagicLinkConsumptionFailed($reason, $request));
 
-        $message = (string) __('email-magic-link::messages.consume_failed');
-        $config = app(MagicLinkConfig::class);
-
-        // A client that negotiated JSON always gets the stable envelope; its
-        // shape is a fixed contract independent of the browser strategy below.
-        if ($this->wantsJson($request)) {
-            return $this->apiError($message, $config->invalidResponseErrorCode(), 422);
-        }
-
-        // The browser response is host-configurable (view/redirect/abort/json,
-        // or a custom class bound in the service provider) but never varies by
-        // the failure reason, so it stays enumeration-resistant.
-        return app(InvalidLinkResponder::class)->respond($request, $message, $failureRoute);
+        // The response itself lives in RejectsGenerically, shared with the invitation
+        // flow. Two copies of "refuse without saying why" is one copy too many: the
+        // moment they can drift, the difference between them is the answer.
+        return $this->genericRejection($request, (string) __('email-magic-link::messages.consume_failed'), $failureRoute);
     }
 }

--- a/src/Http/Controllers/Concerns/RejectsGenerically.php
+++ b/src/Http/Controllers/Concerns/RejectsGenerically.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Controllers\Concerns;
+
+use EmailMagicLink\Contracts\InvalidLinkResponder;
+use EmailMagicLink\Support\MagicLinkConfig;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * The one refusal every dead token gets, whatever killed it.
+ *
+ * Unknown, expired, already spent, revoked, tampered signature -- all of them land
+ * here and come back byte for byte identical. Anything more specific would answer
+ * "was this ever a real link", which is the question the uniformity exists to leave
+ * unanswered.
+ *
+ * Extracted from CompletesMagicLinkLogin so the sign-in flow and the invitation flow
+ * share ONE response path. They used to have one; the moment there were two, they
+ * could drift, and drift between two refusals is exactly what makes them tell apart.
+ */
+trait RejectsGenerically
+{
+    use RespondsToApiClients;
+
+    protected function genericRejection(Request $request, string $message, string $failureRoute): Response
+    {
+        $config = app(MagicLinkConfig::class);
+
+        // A client that negotiated JSON always gets the stable envelope; its
+        // shape is a fixed contract independent of the browser strategy below.
+        if ($this->wantsJson($request)) {
+            return $this->apiError($message, $config->invalidResponseErrorCode(), 422);
+        }
+
+        // The browser response is host-configurable (view/redirect/abort/json,
+        // or a custom class bound in the service provider) but never varies by
+        // the failure reason, so it stays enumeration-resistant.
+        return app(InvalidLinkResponder::class)->respond($request, $message, $failureRoute);
+    }
+}

--- a/src/Http/Controllers/ConsumeCodeController.php
+++ b/src/Http/Controllers/ConsumeCodeController.php
@@ -8,7 +8,6 @@ use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Contracts\UserLookup;
 use EmailMagicLink\Http\Controllers\Concerns\CompletesMagicLinkLogin;
 use EmailMagicLink\Http\Requests\ConsumeCodeRequest;
-use EmailMagicLink\Models\MagicLinkToken;
 use EmailMagicLink\Support\ClaimFailure;
 use EmailMagicLink\Support\MagicLinkConfig;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -40,12 +39,10 @@ final class ConsumeCodeController
         }
 
         $result = $store->claimCode($user, $request->code(), $guard);
-        $claimed = $result->token;
-
-        if (! $result->successful || ! $claimed instanceof MagicLinkToken) {
-            return $this->failedConsumption($request, 'email-magic-link.code.form', $result->failure ?? ClaimFailure::NotFound);
+        if (! $result->succeeded()) {
+            return $this->failedConsumption($request, 'email-magic-link.code.form', $result->failure);
         }
 
-        return $this->completeLogin($request, $claimed, 'email-magic-link.code.form');
+        return $this->completeLogin($request, $result->token, 'email-magic-link.code.form');
     }
 }

--- a/src/Http/Controllers/ConsumeMagicLinkController.php
+++ b/src/Http/Controllers/ConsumeMagicLinkController.php
@@ -6,8 +6,6 @@ namespace EmailMagicLink\Http\Controllers;
 
 use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Http\Controllers\Concerns\CompletesMagicLinkLogin;
-use EmailMagicLink\Models\MagicLinkToken;
-use EmailMagicLink\Support\ClaimFailure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -26,12 +24,10 @@ final class ConsumeMagicLinkController
         $passphrase = $request->string('passphrase')->toString();
 
         $result = $store->claimLink($token, $passphrase !== '' ? $passphrase : null);
-        $claimed = $result->token;
-
-        if (! $result->successful || ! $claimed instanceof MagicLinkToken) {
-            return $this->failedConsumption($request, 'email-magic-link.request.form', $result->failure ?? ClaimFailure::NotFound);
+        if (! $result->succeeded()) {
+            return $this->failedConsumption($request, 'email-magic-link.request.form', $result->failure);
         }
 
-        return $this->completeLogin($request, $claimed, 'email-magic-link.request.form');
+        return $this->completeLogin($request, $result->token, 'email-magic-link.request.form');
     }
 }

--- a/src/Http/Controllers/ShowInvitationController.php
+++ b/src/Http/Controllers/ShowInvitationController.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Controllers;
+
+use EmailMagicLink\Contracts\InvitationStore;
+use EmailMagicLink\Events\InvitationRejected;
+use EmailMagicLink\Http\Controllers\Concerns\RejectsGenerically;
+use EmailMagicLink\Models\Invitation;
+use EmailMagicLink\Support\ClaimFailure;
+use EmailMagicLink\Support\MagicLinkConfig;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\URL;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Renders the host's acceptance screen for a live invitation, and nothing at all
+ * for a dead one.
+ *
+ * Inert by construction: this GET performs no claim, no write and no sign-in, so a
+ * link-following scanner or a browser prefetch cannot burn the invitation before the
+ * invited person ever sees it. Only the POST spends it.
+ *
+ * The order of the three steps is the ticket's fourth promise made structural. The
+ * refusal happens BEFORE the host's view is rendered, so a dead invitation can never
+ * reach a screen that asks for a password -- and it is a promise rather than consumer
+ * discipline only because this package owns the GET.
+ *
+ * The route deliberately carries no `signed` middleware. That middleware answers an
+ * expired signature with 403 and an unknown token with the generic page, and those two
+ * answers are distinguishable. With a seven-day lifetime expiry is the ordinary case,
+ * so the signature is checked here instead and a failure folded into the same refusal
+ * as everything else.
+ */
+final readonly class ShowInvitationController
+{
+    use RejectsGenerically;
+
+    public function __construct(
+        private MagicLinkConfig $config,
+        private Factory $views,
+        private InvitationStore $store,
+    ) {}
+
+    public function __invoke(Request $request, string $token): Response|View
+    {
+        // A tampered or expired signature is NotFound as far as the visitor is
+        // concerned: telling those apart is telling them whether the token was ever real.
+        if (! URL::hasValidSignature($request)) {
+            return $this->refuse($request, ClaimFailure::NotFound);
+        }
+
+        $result = $this->store->peek($token);
+
+        if (! $result->successful || ! $result->invitation instanceof Invitation) {
+            return $this->refuse($request, $result->failure ?? ClaimFailure::NotFound);
+        }
+
+        $view = $this->config->invitationView();
+
+        if ($view === null) {
+            return $this->refuse($request, ClaimFailure::NotFound);
+        }
+
+        return $this->views->make($view, [
+            'token' => $token,
+            'action' => route('email-magic-link.invitation.accept', ['token' => $token]),
+            'email' => $result->invitation->email,
+            'context' => $result->invitation->context,
+            'expiresAt' => $result->invitation->expires_at,
+        ]);
+    }
+
+    private function refuse(Request $request, ClaimFailure $reason): Response
+    {
+        // The reason reaches the application through the event and stops there. It is
+        // never in the response, never in the status code, and the caller passes it in
+        // rather than the refusal looking it up again -- a second lookup would both cost
+        // a query and be wrong for a bad signature, where there is nothing to look up.
+        event(new InvitationRejected($reason, $request));
+
+        return $this->genericRejection(
+            $request,
+            (string) __('email-magic-link::messages.invitation_failed'),
+            'email-magic-link.request.form',
+        );
+    }
+}

--- a/src/Http/Requests/ConsumeCodeRequest.php
+++ b/src/Http/Requests/ConsumeCodeRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Http\Requests;
 
+use EmailMagicLink\Support\MagicLinkConfig;
 use Illuminate\Foundation\Http\FormRequest;
 use Override;
 
@@ -41,8 +42,34 @@ final class ConsumeCodeRequest extends FormRequest
 
         $this->merge([
             'email' => is_string($email) ? mb_strtolower(trim($email)) : $email,
-            'code' => is_string($code) ? strtoupper(preg_replace('/\s+/u', '', $code) ?? $code) : $code,
+            'code' => is_string($code) ? $this->normalizeCode($code) : $code,
         ]);
+    }
+
+    /**
+     * Strip whitespace, then fold case ONLY in the direction the alphabet writes.
+     *
+     * Folding used to be an unconditional `strtoupper`. That is convenient for the
+     * shipped alphabet (upper-case only, so the reader may type lower) and it is
+     * destructive for any other: a mixed alphabet has `a` and `A` as two distinct
+     * characters the generator both mints, and a lower-case alphabet is folded away
+     * from what was minted. Either way the code can never be redeemed, the failure
+     * looks exactly like an expired code, and `max_attempts_per_token` counts down
+     * while nothing names the cause.
+     *
+     * `mb_strtoupper` rather than `strtoupper`: the alphabet is read multibyte-aware
+     * everywhere else, and the byte-wise function mangles a non-ASCII alphabet
+     * instead of folding it.
+     */
+    private function normalizeCode(string $code): string
+    {
+        $stripped = preg_replace('/\s+/u', '', $code) ?? $code;
+
+        return match (app(MagicLinkConfig::class)->codeAlphabetCaseFolding()) {
+            'upper' => mb_strtoupper($stripped),
+            'lower' => mb_strtolower($stripped),
+            default => $stripped,
+        };
     }
 
     public function email(): string

--- a/src/Models/Invitation.php
+++ b/src/Models/Invitation.php
@@ -10,41 +10,40 @@ use Illuminate\Support\Carbon;
 use Override;
 
 /**
- * A single issued magic link or one-time code.
+ * A single issued invitation.
  *
  * Only the keyed hash of the secret is stored. The row is the unit the atomic
- * single-use claim operates on.
+ * single-use claim operates on, and it is addressed by EMAIL rather than by user:
+ * the recipient may have no account yet, which is the whole point.
  *
  * @property int $id
- * @property string $user_id
+ * @property string $email
  * @property string $guard
  * @property string $token_hash
- * @property string $channel
- * @property int $attempts
- * @property int $uses_remaining
- * @property string|null $passphrase_hash
+ * @property array<string, mixed>|null $context
+ * @property string|null $invited_by
  * @property Carbon $expires_at
- * @property Carbon|null $consumed_at
+ * @property Carbon|null $accepted_at
+ * @property Carbon|null $revoked_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  */
-class MagicLinkToken extends Model
+class Invitation extends Model
 {
-    protected $table = 'magic_link_tokens';
+    protected $table = 'email_magic_link_invitations';
 
     /**
      * @var list<string>
      */
     protected $fillable = [
-        'user_id',
+        'email',
         'guard',
         'token_hash',
-        'channel',
-        'attempts',
-        'uses_remaining',
-        'passphrase_hash',
+        'context',
+        'invited_by',
         'expires_at',
-        'consumed_at',
+        'accepted_at',
+        'revoked_at',
     ];
 
     /**
@@ -54,10 +53,10 @@ class MagicLinkToken extends Model
     protected function casts(): array
     {
         return [
-            'attempts' => 'integer',
-            'uses_remaining' => 'integer',
+            'context' => 'array',
             'expires_at' => 'datetime',
-            'consumed_at' => 'datetime',
+            'accepted_at' => 'datetime',
+            'revoked_at' => 'datetime',
         ];
     }
 
@@ -66,13 +65,13 @@ class MagicLinkToken extends Model
         return $this->expires_at->lessThanOrEqualTo($now ?? Carbon::now());
     }
 
-    public function isConsumed(): bool
+    public function isAccepted(): bool
     {
-        return $this->consumed_at !== null;
+        return $this->accepted_at !== null;
     }
 
-    public function requiresPassphrase(): bool
+    public function isRevoked(): bool
     {
-        return $this->passphrase_hash !== null;
+        return $this->revoked_at !== null;
     }
 }

--- a/src/Stores/DefaultInvitationStore.php
+++ b/src/Stores/DefaultInvitationStore.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Stores;
+
+use Carbon\CarbonInterface;
+use EmailMagicLink\Contracts\InvitationStore;
+use EmailMagicLink\Models\Invitation;
+use EmailMagicLink\Support\ClaimFailure;
+use EmailMagicLink\Support\InvitationClaimResult;
+use EmailMagicLink\Support\IssuedInvitationToken;
+use EmailMagicLink\Support\MagicLinkConfig;
+use EmailMagicLink\Support\TokenHasher;
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Database\Connection;
+use Illuminate\Support\Carbon;
+
+/**
+ * Eloquent-backed invitation store.
+ */
+final readonly class DefaultInvitationStore implements InvitationStore
+{
+    public function __construct(
+        private MagicLinkConfig $config,
+        private TokenHasher $hasher,
+    ) {}
+
+    public function issue(string $email, string $guard, ?array $context = null, ?string $invitedBy = null, ?int $ttl = null): IssuedInvitationToken
+    {
+        $normalized = $this->normalize($email);
+
+        return $this->connection()->transaction(function () use ($normalized, $guard, $context, $invitedBy, $ttl): IssuedInvitationToken {
+            $now = Carbon::now();
+            $plaintext = $this->generateToken();
+
+            $record = new Invitation;
+            $record->email = $normalized;
+            $record->guard = $guard;
+            $record->token_hash = $this->hasher->hash($plaintext);
+            $record->context = $context;
+            $record->invited_by = $invitedBy;
+            $record->expires_at = $now->copy()->addSeconds($ttl !== null && $ttl > 0 ? $ttl : $this->config->invitationTtl());
+            $record->accepted_at = null;
+            $record->revoked_at = null;
+            $record->save();
+
+            // INSERT FIRST, then revoke everything below this row's id. That order is
+            // race-free without gap locks, so it is exactly as strong on PostgreSQL as on
+            // MySQL: the writer holding the highest id supersedes every earlier one, and
+            // nobody can supersede IT without holding an id that is higher still.
+            //
+            // Revoking first and inserting after is the obvious order and the wrong one --
+            // two concurrent invites would each revoke what they saw and then both insert,
+            // leaving two live links for one address. That is the failure the ticket calls
+            // out by name.
+            //
+            // Already ACCEPTED rows are left alone: they are a record of something that
+            // happened, not an open door.
+            Invitation::query()
+                ->where('email', $normalized)
+                ->where('guard', $guard)
+                ->where('id', '<', $record->id)
+                ->whereNull('accepted_at')
+                ->whereNull('revoked_at')
+                ->update(['revoked_at' => $now]);
+
+            return new IssuedInvitationToken($plaintext, $record);
+        });
+    }
+
+    public function peek(string $token): InvitationClaimResult
+    {
+        $now = Carbon::now();
+        $hash = $this->hasher->hash($token);
+
+        $live = Invitation::query()
+            ->where('token_hash', $hash)
+            ->whereNull('accepted_at')
+            ->whereNull('revoked_at')
+            ->where('expires_at', '>', $now)
+            ->first();
+
+        return $live instanceof Invitation
+            ? InvitationClaimResult::success($live)
+            : InvitationClaimResult::failed($this->classify($hash, $now));
+    }
+
+    public function claim(string $token): InvitationClaimResult
+    {
+        return $this->connection()->transaction(function () use ($token): InvitationClaimResult {
+            $now = Carbon::now();
+            $hash = $this->hasher->hash($token);
+
+            if (! $this->atomicClaim($hash, $now)) {
+                return InvitationClaimResult::failed($this->classify($hash, $now));
+            }
+
+            $record = Invitation::query()->where('token_hash', $hash)->first();
+
+            return $record instanceof Invitation
+                ? InvitationClaimResult::success($record)
+                : InvitationClaimResult::failed(ClaimFailure::NotFound);
+        });
+    }
+
+    public function revoke(string $email, string $guard): int
+    {
+        return Invitation::query()
+            ->where('email', $this->normalize($email))
+            ->where('guard', $guard)
+            ->whereNull('accepted_at')
+            ->whereNull('revoked_at')
+            ->update(['revoked_at' => Carbon::now()]);
+    }
+
+    public function purge(): int
+    {
+        $now = Carbon::now();
+        $retainUntil = $now->copy()->subDays($this->config->invitationRetainAcceptedDays());
+
+        $deleted = Invitation::query()
+            ->where(function (Builder $query) use ($now): void {
+                // Never accepted and past its lifetime: nothing to learn from it.
+                $query->where('expires_at', '<=', $now)
+                    ->whereNull('accepted_at')
+                    ->whereNull('revoked_at');
+            })
+            ->orWhere(function (Builder $query) use ($retainUntil): void {
+                // Settled rows carry the invited address in the clear, so they are kept
+                // only as long as the configured retention window -- an audit decision,
+                // which is why it is a config key rather than a constant.
+                $query->whereNotNull('accepted_at')->where('accepted_at', '<=', $retainUntil);
+            })
+            ->orWhere(function (Builder $query) use ($retainUntil): void {
+                $query->whereNotNull('revoked_at')->where('revoked_at', '<=', $retainUntil);
+            })
+            ->delete();
+
+        return is_int($deleted) ? $deleted : 0;
+    }
+
+    /**
+     * One conditional UPDATE. Every reason an invitation cannot be claimed is a
+     * predicate here, so the check and the write cannot drift apart.
+     *
+     * Deliberately simpler than the sign-in claim next door: there is no use counter,
+     * no CASE, and therefore no SET list whose evaluation order matters. That
+     * subtlety exists over there because MySQL reads left to right within SET; here
+     * there is nothing to read.
+     */
+    private function atomicClaim(string $hash, CarbonInterface $now): bool
+    {
+        $connection = $this->connection();
+
+        $sql = 'update email_magic_link_invitations set accepted_at = ?, updated_at = ? '
+            .'where token_hash = ? and accepted_at is null and revoked_at is null and expires_at > ?';
+        $bindings = [$now, $now, $hash, $now];
+
+        if ($connection->getDriverName() === 'pgsql') {
+            // Explicit `false`: select() defaults to the READ connection, and this is an
+            // UPDATE. The caller holds a transaction, so it would resolve to the write PDO
+            // anyway -- but stating it here keeps the safety a property of this statement
+            // rather than of whoever calls it.
+            //
+            // Three reported survivors sit on this line and NONE of them is a testable gap.
+            // Recorded so the next pass spends its measurements elsewhere:
+            //
+            //   `false` -> `true`   equivalent for the only caller. Measured with a real
+            //                       read/write split configured: inside a transaction
+            //                       getReadPdo() returns the write PDO, so the argument
+            //                       changes nothing. What actually pins this to the write
+            //                       connection is the transaction, and InvitationClaim-
+            //                       PostgresTest asserts that directly.
+            //   drop ' returning id'  equivalent. Measured against real postgres: for an
+            //                       UPDATE, select() answers with one result when a row
+            //                       matched and none when none did -- with or without
+            //                       RETURNING. Those are the only two cases `!== []`
+            //                       distinguishes. The clause states the intent; it is not
+            //                       what makes the check work.
+            //   negate the driver test  equivalent. Postgres answers correctly through the
+            //                       update() branch too, and SQLite has supported RETURNING
+            //                       since 3.35, so both branches work on both drivers.
+            //
+            // None of that is a reason to simplify the line: the explicit `false` is the
+            // safety for a caller that does NOT hold a transaction, and RETURNING is what
+            // makes the row count trustworthy rather than incidental.
+            return $connection->select($sql.' returning id', $bindings, false) !== [];
+        }
+
+        return $connection->update($sql, $bindings) === 1;
+    }
+
+    /**
+     * Why a claim or a peek found nothing. Reuses the sign-in failure enum: an
+     * invitation fails for the same three reasons a link does.
+     */
+    private function classify(string $hash, CarbonInterface $now): ClaimFailure
+    {
+        $record = Invitation::query()->where('token_hash', $hash)->first();
+
+        if (! $record instanceof Invitation) {
+            return ClaimFailure::NotFound;
+        }
+
+        if ($record->isAccepted() || $record->isRevoked()) {
+            return ClaimFailure::AlreadyConsumed;
+        }
+
+        return $record->isExpired($now) ? ClaimFailure::Expired : ClaimFailure::NotFound;
+    }
+
+    /**
+     * The same normalization the request path applies, so an invitation issued for
+     * "Alice@Example.com " is found by a lookup for "alice@example.com".
+     */
+    private function normalize(string $email): string
+    {
+        return mb_strtolower(trim($email));
+    }
+
+    /**
+     * 256 bits, URL-safe, no padding -- the same shape as a sign-in link token.
+     */
+    private function generateToken(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+    }
+
+    private function connection(): Connection
+    {
+        return (new Invitation)->getConnection();
+    }
+}

--- a/src/Stores/DefaultTokenStore.php
+++ b/src/Stores/DefaultTokenStore.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Stores;
 
+use Carbon\CarbonInterface;
 use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Models\MagicLinkToken;
 use EmailMagicLink\Support\ClaimFailure;
@@ -42,8 +43,9 @@ final readonly class DefaultTokenStore implements TokenStore
             ? max(1, $maxUses ?? $this->config->maxUses())
             : 1;
 
-        // A passphrase gates links only (a code is itself the secret). Hashed with
-        // bcrypt because it is a human-chosen shared secret, not a random token.
+        // A passphrase gates links only (a code is itself the secret). Put through the
+        // host's configured hasher rather than the raw-token hash: it is a human-chosen
+        // shared secret, so it needs a slow, salted algorithm, not a fast digest.
         $passphraseHash = $channel === 'link' && is_string($passphrase) && $passphrase !== ''
             ? Hash::make($passphrase)
             : null;
@@ -78,27 +80,40 @@ final readonly class DefaultTokenStore implements TokenStore
 
     public function claimLink(string $token, ?string $passphrase = null): ClaimResult
     {
-        $now = Carbon::now();
-        $hash = $this->hasher->hash($token);
+        // The whole read-check-claim-read runs in a transaction, and the reason is the
+        // READ side rather than the write. Connection::getReadPdo() hands back the read
+        // connection unless a transaction is open, `sticky` is set after a prior write, or
+        // the app forced read-on-write — and claiming a link satisfies none of those: it is
+        // usually the first database work of the request. On a deployment with a read
+        // connection configured, every lookup here would go to the replica, where a link
+        // issued moments ago may not have arrived yet; a valid link would be reported as
+        // unknown, and only under replication lag, which is exactly the failure nobody can
+        // reproduce. Opening a transaction makes all four statements use the write
+        // connection, and makes the sequence atomic on top — the same reasoning claimCode()
+        // already documents below.
+        return $this->connection()->transaction(function () use ($token, $passphrase): ClaimResult {
+            $now = Carbon::now();
+            $hash = $this->hasher->hash($token);
 
-        // Verify the passphrase BEFORE the atomic claim, so a wrong passphrase
-        // never spends a use of a multi-use link. A generic failure keeps the
-        // response indistinguishable from an unknown or expired token.
-        $existing = $this->findLinkByHash($hash);
+            // Verify the passphrase BEFORE the atomic claim, so a wrong passphrase
+            // never spends a use of a multi-use link. A generic failure keeps the
+            // response indistinguishable from an unknown or expired token.
+            $existing = $this->findLinkByHash($hash);
 
-        if ($existing?->passphrase_hash !== null && ! $this->passphraseMatches($passphrase, $existing->passphrase_hash)) {
-            return ClaimResult::failed(ClaimFailure::InvalidPassphrase);
-        }
+            if ($existing?->passphrase_hash !== null && ! $this->passphraseMatches($passphrase, $existing->passphrase_hash)) {
+                return ClaimResult::failed(ClaimFailure::InvalidPassphrase);
+            }
 
-        if ($this->atomicClaim('token_hash', $hash, 'link', $now)) {
-            $model = $this->findLinkByHash($hash);
+            if ($this->atomicClaim('token_hash', $hash, 'link', $now)) {
+                $model = $this->findLinkByHash($hash);
 
-            return $model instanceof MagicLinkToken
-                ? ClaimResult::success($model)
-                : ClaimResult::failed(ClaimFailure::NotFound);
-        }
+                return $model instanceof MagicLinkToken
+                    ? ClaimResult::success($model)
+                    : ClaimResult::failed(ClaimFailure::NotFound);
+            }
 
-        return ClaimResult::failed($this->classifyLinkFailure($hash, $now));
+            return ClaimResult::failed($this->classifyLinkFailure($hash, $now));
+        });
     }
 
     public function requiresPassphrase(string $token): bool
@@ -167,7 +182,7 @@ final readonly class DefaultTokenStore implements TokenStore
         return is_int($deleted) ? $deleted : 0;
     }
 
-    private function recordFailedCodeAttempt(MagicLinkToken $token, int $max, Carbon $now): ClaimResult
+    private function recordFailedCodeAttempt(MagicLinkToken $token, int $max, CarbonInterface $now): ClaimResult
     {
         $connection = $this->connection();
 
@@ -211,7 +226,7 @@ final readonly class DefaultTokenStore implements TokenStore
      * pre-decrement count. PostgreSQL and SQLite always read the old row values,
      * so the ordering is a no-op there — but it makes all three engines agree.
      */
-    private function atomicClaim(string $column, string $value, string $channel, Carbon $now): bool
+    private function atomicClaim(string $column, string $value, string $channel, CarbonInterface $now): bool
     {
         $connection = $this->connection();
 
@@ -222,7 +237,12 @@ final readonly class DefaultTokenStore implements TokenStore
         $bindings = [$now, $now, $value, $channel, $now];
 
         if ($connection->getDriverName() === 'pgsql') {
-            return $connection->select($sql.' returning id', $bindings) !== [];
+            // Explicit `false`: select() defaults to the READ connection, and this one is
+            // an UPDATE. Both callers hold a transaction, so getReadPdo() would return the
+            // write PDO anyway — but that makes the safety a property of the CALLER, and a
+            // future third caller would inherit a silent write-to-replica instead of a
+            // visible mistake.
+            return $connection->select($sql.' returning id', $bindings, false) !== [];
         }
 
         return $connection->update($sql, $bindings) === 1;
@@ -241,7 +261,7 @@ final readonly class DefaultTokenStore implements TokenStore
         return is_string($passphrase) && $passphrase !== '' && Hash::check($passphrase, $hash);
     }
 
-    private function classifyLinkFailure(string $hash, Carbon $now): ClaimFailure
+    private function classifyLinkFailure(string $hash, CarbonInterface $now): ClaimFailure
     {
         $row = $this->findLinkByHash($hash);
 
@@ -262,7 +282,13 @@ final readonly class DefaultTokenStore implements TokenStore
     {
         // The same canonical distinct-character set the entropy guardrail
         // certifies, so the generated distribution matches the proven keyspace.
-        $characters = $this->config->codeAlphabetCharacters();
+        //
+        // EFFECTIVE, not configured: minting a character that the fold then collapses
+        // produces a code that can never be redeemed -- the same failure this fold
+        // was corrected to remove, arriving from the other side. The generator and
+        // the guardrail must read the same set or one of them is describing an
+        // alphabet that does not exist at comparison time.
+        $characters = $this->config->effectiveCodeAlphabetCharacters();
         $length = $this->config->codeLength();
         $bound = count($characters) - 1;
 

--- a/src/Support/AcceptedInvitation.php
+++ b/src/Support/AcceptedInvitation.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+/**
+ * The invitation that was just spent, as your handler sees it.
+ *
+ * A flat value rather than the Eloquent model on purpose: the handler is a domain
+ * seam, not a place to edit the package's rows. Everything it needs to act is here,
+ * and nothing it could use to change the invitation's own state is.
+ */
+final readonly class AcceptedInvitation
+{
+    /**
+     * @param  array<string, mixed>|null  $context  What the inviter decided in advance.
+     *                                              Possibly a week old — check it against
+     *                                              current state before acting on it.
+     */
+    public function __construct(
+        public int $id,
+        public string $email,
+        public string $guard,
+        public ?array $context,
+        public ?string $invitedBy,
+    ) {}
+}

--- a/src/Support/ClaimResult.php
+++ b/src/Support/ClaimResult.php
@@ -26,4 +26,22 @@ final readonly class ClaimResult
     {
         return new self(false, null, $failure);
     }
+
+    /**
+     * Whether the claim succeeded, stated so the type system knows what that implies.
+     *
+     * The constructor is private and there are exactly two ways in, so `successful` and
+     * `token` are two views of one fact: success always carries a token, failure never
+     * does and always carries a reason. Callers could not express that, and so wrote it
+     * out again as a second check on every branch -- a condition no input can reach, which
+     * is exactly the shape that leaves a mutant alive with no test able to kill it.
+     *
+     * @phpstan-assert-if-true !null $this->token
+     *
+     * @phpstan-assert-if-false !null $this->failure
+     */
+    public function succeeded(): bool
+    {
+        return $this->successful;
+    }
 }

--- a/src/Support/ConfirmationUrl.php
+++ b/src/Support/ConfirmationUrl.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace EmailMagicLink\Support;
 
 use EmailMagicLink\Models\MagicLinkToken;
-use Illuminate\Support\Facades\URL;
 
 /**
  * Builds the signed, single-use confirmation URL for an issued link token.
@@ -13,6 +12,9 @@ use Illuminate\Support\Facades\URL;
  * Centralised so the bundled email flow and the Mint-API emit the byte-for-byte
  * same signed GET URL: the inert confirmation page. Only the POST consume route
  * mutates state, so this URL is safe for link-following scanners and prefetch.
+ *
+ * The signing itself now lives in SignedTokenUrl, shared with the invitation link.
+ * This signature is public API and stays exactly as it was.
  */
 final class ConfirmationUrl
 {
@@ -24,31 +26,6 @@ final class ConfirmationUrl
      */
     public static function for(MagicLinkToken $record, string $plaintext, ?string $baseUrl = null): string
     {
-        if ($baseUrl === null || $baseUrl === '') {
-            return self::sign($record, $plaintext);
-        }
-
-        // Force the host AND scheme from the base URL for this one signing call,
-        // then restore both so no later URL generation in the request inherits
-        // the tenant host. Forcing the scheme too makes an https base URL sign as
-        // https even when the app itself is served over http.
-        URL::forceRootUrl($baseUrl);
-        URL::forceScheme(parse_url($baseUrl, PHP_URL_SCHEME) ?: '');
-
-        try {
-            return self::sign($record, $plaintext);
-        } finally {
-            URL::forceRootUrl(null);
-            URL::forceScheme('');
-        }
-    }
-
-    private static function sign(MagicLinkToken $record, string $plaintext): string
-    {
-        return URL::temporarySignedRoute(
-            'email-magic-link.confirm',
-            $record->expires_at,
-            ['token' => $plaintext],
-        );
+        return SignedTokenUrl::for('email-magic-link.confirm', $record->expires_at, $plaintext, $baseUrl);
     }
 }

--- a/src/Support/DefaultInvitationIssuer.php
+++ b/src/Support/DefaultInvitationIssuer.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use EmailMagicLink\Contracts\InvitationIssuer;
+use EmailMagicLink\Contracts\InvitationStore;
+use EmailMagicLink\Exceptions\InvitationsDisabledException;
+use EmailMagicLink\Exceptions\UnknownGuardException;
+
+/**
+ * Mints invitations and the signed URL that carries them.
+ */
+final readonly class DefaultInvitationIssuer implements InvitationIssuer
+{
+    public function __construct(
+        private InvitationStore $store,
+        private MagicLinkConfig $config,
+    ) {}
+
+    public function invite(string $email, ?string $guard = null, ?array $context = null, ?string $invitedBy = null, ?string $baseUrl = null): IssuedInvitation
+    {
+        $resolvedGuard = $this->prepare($guard);
+
+        $issued = $this->store->issue($email, $resolvedGuard, $context, $invitedBy);
+
+        return new IssuedInvitation(
+            SignedTokenUrl::for('email-magic-link.invitation.show', $issued->record->expires_at, $issued->plaintext, $baseUrl),
+            $issued->record->email,
+            $resolvedGuard,
+            $issued->record->expires_at,
+            (int) ceil($this->config->invitationTtl() / 60),
+        );
+    }
+
+    public function revoke(string $email, ?string $guard = null): int
+    {
+        return $this->store->revoke($email, $this->prepare($guard));
+    }
+
+    /**
+     * Validate the request and return the guard to issue against. Nothing is
+     * persisted until every check here has passed, so a rejected request mints
+     * no row.
+     *
+     * Note what is deliberately ABSENT compared to the sign-in issuer: there is no
+     * assertUserBelongsToGuard(). That check re-resolves the user through the
+     * guard's provider, and requiring it is precisely what makes an invitation to
+     * somebody without an account impossible — the gap this whole feature exists to
+     * close. The guard is still narrowed to the configured allow-list, so an
+     * invitation can never be minted against a guard the host has not opened up.
+     */
+    private function prepare(?string $guard): string
+    {
+        if (! $this->config->enabled() || ! $this->config->invitationsEnabled()) {
+            throw InvitationsDisabledException::make();
+        }
+
+        if ($guard === null) {
+            return $this->config->guard();
+        }
+
+        $allowed = $this->config->allowedGuards();
+
+        if (! in_array($guard, $allowed, true)) {
+            throw UnknownGuardException::for($guard, $allowed);
+        }
+
+        return $guard;
+    }
+}

--- a/src/Support/EntropyGuard.php
+++ b/src/Support/EntropyGuard.php
@@ -44,7 +44,7 @@ final readonly class EntropyGuard
 
     private function validateCodeKeyspace(): void
     {
-        $alphabetSize = count($this->config->codeAlphabetCharacters());
+        $alphabetSize = count($this->config->effectiveCodeAlphabetCharacters());
         $length = $this->config->codeLength();
         $maxAttempts = $this->config->maxAttemptsPerToken();
         $safetyFactor = $this->config->entropySafetyFactor();

--- a/src/Support/InvitationClaimResult.php
+++ b/src/Support/InvitationClaimResult.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use EmailMagicLink\Models\Invitation;
+
+/**
+ * Outcome of a peek or an atomic claim: either the invitation, or the reason it failed.
+ *
+ * Reuses ClaimFailure rather than introducing a parallel enum. The reasons are the same
+ * three an invitation can have -- unknown, expired, already spent -- and a caller that
+ * already handles the sign-in failures handles these unchanged.
+ */
+final readonly class InvitationClaimResult
+{
+    private function __construct(
+        public bool $successful,
+        public ?Invitation $invitation,
+        public ?ClaimFailure $failure,
+    ) {}
+
+    public static function success(Invitation $invitation): self
+    {
+        return new self(true, $invitation, null);
+    }
+
+    public static function failed(ClaimFailure $failure): self
+    {
+        return new self(false, null, $failure);
+    }
+}

--- a/src/Support/InvitationGuard.php
+++ b/src/Support/InvitationGuard.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use EmailMagicLink\Contracts\InvitationHandler;
+use EmailMagicLink\Exceptions\InvitationsMisconfiguredException;
+
+/**
+ * Refuses to boot an installation that has invitations on but cannot serve them.
+ *
+ * Same shape and the same reasoning as EntropyGuard: the alternative to failing here
+ * is failing at the moment an invited person clicks their link, which is the worst
+ * time to discover it and the hardest place to see it. Both requirements are things
+ * only the host can supply, so neither can be defaulted into working.
+ */
+final readonly class InvitationGuard
+{
+    public function __construct(private MagicLinkConfig $config) {}
+
+    public function validate(): void
+    {
+        if (! $this->config->invitationsEnabled()) {
+            return;
+        }
+
+        $handler = $this->config->invitationHandler();
+
+        if ($handler === null) {
+            throw InvitationsMisconfiguredException::missingHandler();
+        }
+
+        // class_exists AND the contract check, in that order: a typo in the class name
+        // and a class that simply does not implement the interface are different
+        // mistakes, and telling them apart is the difference between a useful message
+        // and "something is wrong with your handler".
+        if (! class_exists($handler) || ! is_a($handler, InvitationHandler::class, true)) {
+            throw InvitationsMisconfiguredException::handlerContract($handler);
+        }
+
+        if ($this->config->invitationView() === null) {
+            throw InvitationsMisconfiguredException::missingView();
+        }
+    }
+}

--- a/src/Support/IssuedCode.php
+++ b/src/Support/IssuedCode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Support;
 
-use Illuminate\Support\Carbon;
+use Carbon\CarbonInterface;
 
 /**
  * A freshly minted one-time code, ready to deliver over any channel.
@@ -16,7 +16,7 @@ final readonly class IssuedCode
 {
     public function __construct(
         public string $code,
-        public Carbon $expiresAt,
+        public CarbonInterface $expiresAt,
         public int $expiresInMinutes,
     ) {}
 }

--- a/src/Support/IssuedInvitation.php
+++ b/src/Support/IssuedInvitation.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use Carbon\CarbonInterface;
+
+/**
+ * A freshly issued invitation, ready to deliver over any channel.
+ *
+ * Deliver `url` verbatim. Unlike IssuedCode there is deliberately no plaintext
+ * property: a code has to be shown to the person typing it, whereas an invitation
+ * token is only ever useful inside its URL. Not exposing it separately means there
+ * is no second copy for a log line or an exception dump to pick up.
+ */
+final readonly class IssuedInvitation
+{
+    public function __construct(
+        public string $url,
+        public string $email,
+        public string $guard,
+        public CarbonInterface $expiresAt,
+        public int $expiresInMinutes,
+    ) {}
+}

--- a/src/Support/IssuedInvitationToken.php
+++ b/src/Support/IssuedInvitationToken.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use EmailMagicLink\Models\Invitation;
+
+/**
+ * A freshly issued invitation, as the store hands it back: the plaintext secret
+ * and the row that carries only its hash.
+ *
+ * Internal. The public Mint surface is IssuedInvitation, which deliberately does
+ * NOT expose the plaintext -- it exposes the URL that already contains it.
+ */
+final readonly class IssuedInvitationToken
+{
+    public function __construct(
+        public string $plaintext,
+        public Invitation $record,
+    ) {}
+}

--- a/src/Support/IssuedLink.php
+++ b/src/Support/IssuedLink.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Support;
 
-use Illuminate\Support\Carbon;
+use Carbon\CarbonInterface;
 
 /**
  * A freshly minted magic link, ready to deliver over any channel.
@@ -17,7 +17,7 @@ final readonly class IssuedLink
 {
     public function __construct(
         public string $url,
-        public Carbon $expiresAt,
+        public CarbonInterface $expiresAt,
         public int $expiresInMinutes,
     ) {}
 }

--- a/src/Support/MagicLinkConfig.php
+++ b/src/Support/MagicLinkConfig.php
@@ -95,6 +95,74 @@ final readonly class MagicLinkConfig
         return array_values(array_unique(mb_str_split($this->codeAlphabet())));
     }
 
+    /**
+     * How a submitted code must be folded before it is compared, derived from the
+     * configured alphabet rather than assumed.
+     *
+     * `null` means DO NOT FOLD. That is the case for an alphabet that writes both
+     * cases: there `a` and `A` are two different characters, the generator mints
+     * both, and folding either way destroys codes that can then never be redeemed
+     * -- silently, looking exactly like an expired code while the attempt counter
+     * runs down.
+     *
+     * The direction matters as much as the decision. Folding was unconditionally
+     * UPWARD, which is right for the shipped alphabet and wrong for a lower-case
+     * one: the generator mints `abc`, the comparison sees `ABC`, and that alphabet
+     * is as unusable as a mixed one. Nobody reported it because nobody configured
+     * one -- the defect was in the same line the whole time.
+     *
+     * Digits and symbols answer `null` too, and correctly so: they have no case,
+     * so there is nothing to fold and no behavior to change.
+     *
+     * @return 'upper'|'lower'|null
+     */
+    public function codeAlphabetCaseFolding(): ?string
+    {
+        $alphabet = $this->codeAlphabet();
+
+        // The same test `OneTimeCodeFieldTest` already ran to decide whether the
+        // rendered field may widen its validation pattern -- it had the derivation
+        // right while the code that folds did not. Keeping ONE copy is the point: a
+        // field that accepts a case the request then folds away, or the reverse, is
+        // exactly the drift two independent derivations produce.
+        $hasUpper = preg_match('/\p{Lu}/u', $alphabet) === 1;
+        $hasLower = preg_match('/\p{Ll}/u', $alphabet) === 1;
+
+        if ($hasUpper === $hasLower) {
+            return null;
+        }
+
+        return $hasUpper ? 'upper' : 'lower';
+    }
+
+    /**
+     * The alphabet as it EXISTS AT COMPARISON TIME, which is what the entropy
+     * guardrail must certify.
+     *
+     * Under a fold, characters collapse into one another, so counting the
+     * configured distinct characters overstates the keyspace -- the guard whose
+     * only job is to refuse a weak scheme would certify one that is weaker than
+     * it measured. With the fold now derived (a mixed alphabet is no longer
+     * folded at all) the two sets agree again in every case, and this method is
+     * what keeps them agreeing if the derivation ever changes.
+     *
+     * @return list<string>
+     */
+    public function effectiveCodeAlphabetCharacters(): array
+    {
+        $fold = $this->codeAlphabetCaseFolding();
+
+        if ($fold === null) {
+            return $this->codeAlphabetCharacters();
+        }
+
+        $alphabet = $fold === 'upper'
+            ? mb_strtoupper($this->codeAlphabet())
+            : mb_strtolower($this->codeAlphabet());
+
+        return array_values(array_unique(mb_str_split($alphabet)));
+    }
+
     public function maxAttemptsPerToken(): int
     {
         return $this->int($this->config->get('email-magic-link.max_attempts_per_token'), 0);
@@ -513,6 +581,75 @@ final readonly class MagicLinkConfig
             'max' => max(1, $this->int($limit['max'] ?? null, $defaultMax)),
             'per_minutes' => max(1, $this->int($limit['per_minutes'] ?? null, 1)),
         ];
+    }
+
+    /**
+     * Whether the invitation channel is registered at all.
+     *
+     * Off by default and deliberately so: invitations need a host-supplied handler and
+     * acceptance view to mean anything, so a package that switched them on for everybody
+     * would boot into a misconfiguration nobody asked for.
+     */
+    public function invitationsEnabled(): bool
+    {
+        return $this->bool($this->config->get('email-magic-link.invitations.enabled'), false);
+    }
+
+    /**
+     * How long an invitation stays valid, in seconds. Floored at a minute, because a
+     * lifetime shorter than the mail takes to arrive is never what anyone meant.
+     */
+    public function invitationTtl(): int
+    {
+        return max(60, $this->int($this->config->get('email-magic-link.invitations.ttl'), 604800));
+    }
+
+    public function invitationStore(): ?string
+    {
+        $store = $this->config->get('email-magic-link.invitations.store');
+
+        return is_string($store) && $store !== '' ? $store : null;
+    }
+
+    /**
+     * The host class that decides what acceptance MEANS -- setting a password, creating
+     * membership, granting roles. Returned raw rather than resolved so the boot guard can
+     * name the class that is missing or does not implement the contract.
+     */
+    public function invitationHandler(): ?string
+    {
+        $handler = $this->config->get('email-magic-link.invitations.handler');
+
+        return is_string($handler) && $handler !== '' ? $handler : null;
+    }
+
+    /**
+     * The host's acceptance view. A raw view NAME, not a resolved view: this package
+     * bundles no acceptance screen, because one shipping with a password field would put
+     * credential handling inside a package that deliberately owns none.
+     */
+    public function invitationView(): ?string
+    {
+        $view = $this->config->get('email-magic-link.invitations.view');
+
+        return is_string($view) && $view !== '' ? $view : null;
+    }
+
+    public function invitationRedirectTo(): string
+    {
+        return $this->string($this->config->get('email-magic-link.invitations.redirect_to'), '/');
+    }
+
+    /**
+     * How long settled invitations are kept before the purge removes them.
+     *
+     * These rows carry the invited address in the clear, so the window is a data-retention
+     * decision rather than a technical one -- which is why it is configurable and why zero
+     * (delete as soon as they settle) is a legitimate answer.
+     */
+    public function invitationRetainAcceptedDays(): int
+    {
+        return max(0, $this->int($this->config->get('email-magic-link.invitations.retain_accepted_days'), 30));
     }
 
     private function string(mixed $value, string $default): string

--- a/src/Support/SignedTokenUrl.php
+++ b/src/Support/SignedTokenUrl.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\URL;
+
+/**
+ * Builds a temporary signed URL carrying a plaintext token, optionally against
+ * another host.
+ *
+ * Extracted so the sign-in confirmation link and the invitation link are built by
+ * the SAME code. The host override is the part worth centralising: it forces the
+ * root URL and the scheme for one signing call and restores both in a `finally`,
+ * and a second copy of that would be a second chance to forget the restore -- at
+ * which point every later URL in the request silently inherits a tenant host.
+ */
+final class SignedTokenUrl
+{
+    /**
+     * @param  string|null  $baseUrl  Override the host the URL is built for (e.g. a
+     *                                tenant domain). The signature is computed over
+     *                                that final host, so the URL verifies only when
+     *                                visited there -- never an attacker's.
+     */
+    public static function for(string $routeName, CarbonInterface $expiresAt, string $plaintext, ?string $baseUrl = null): string
+    {
+        if ($baseUrl === null || $baseUrl === '') {
+            return self::sign($routeName, $expiresAt, $plaintext);
+        }
+
+        // Force the host AND scheme from the base URL for this one signing call,
+        // then restore both so no later URL generation in the request inherits
+        // the tenant host. Forcing the scheme too makes an https base URL sign as
+        // https even when the app itself is served over http.
+        URL::forceRootUrl($baseUrl);
+        URL::forceScheme(parse_url($baseUrl, PHP_URL_SCHEME) ?: '');
+
+        try {
+            return self::sign($routeName, $expiresAt, $plaintext);
+        } finally {
+            URL::forceRootUrl(null);
+            URL::forceScheme('');
+        }
+    }
+
+    private static function sign(string $routeName, CarbonInterface $expiresAt, string $plaintext): string
+    {
+        return URL::temporarySignedRoute($routeName, $expiresAt, ['token' => $plaintext]);
+    }
+}


### PR DESCRIPTION

### Added

- **Invitation tokens — the storage half.** A magic link signs in somebody who already
  exists; an invitation puts an account into service for an address that may have no
  account at all. The two cannot share a table: every sign-in row is bound to an indexed,
  NOT NULL `user_id`, and widening that column would mean altering a populated table in
  every application that already installed this package.

  So invitations get their own table, `email_magic_link_invitations`, with their own store
  behind the `EmailMagicLink\Contracts\InvitationStore` contract. The separation also
  removes a filter someone could forget: the sign-in store narrows on `channel = 'link'`,
  and here there is no shared table to narrow, so an invitation token cannot reach the
  sign-in path even in principle.

  What the store guarantees: the plaintext is never stored, only a keyed hash; issuing
  again supersedes the previous invitation for the same address and guard, so re-inviting
  never leaves two working links behind; looking at an invitation consumes nothing; and
  claiming one is a single conditional UPDATE, so two concurrent claims cannot both
  succeed.

  The `EmailMagicLink\Contracts\InvitationIssuer` contract mints one and hands back the
  signed URL, and `EmailMagicLink\Contracts\InvitationHandler` is where you say what
  accepting one MEANS — setting a password, creating membership, granting the roles the
  inviter chose. Return an authenticatable from it and the package signs that user in
  through the same path a magic link uses; return null and the invitation is accepted
  without a session.

  Turning invitations on requires both a handler and an acceptance view, and the package
  refuses to boot without them rather than failing at the moment an invited person clicks
  their link. No acceptance screen ships with it: one carrying a password field would put
  credential handling inside a package that deliberately handles none.

  `email-magic-link:purge` clears settled invitations along with expired tokens, so there
  is no second command to schedule. The line only appears when invitations are on.

  Two routes carry the acceptance, and the package owns both. The GET is inert — it
  verifies the signature, checks the invitation, and only then renders your view — so an
  email security scanner following the link cannot burn it, and a dead invitation is
  refused *before* the recipient is asked for anything. Only the POST spends it, and it
  runs the claim and your handler in one transaction: if your handler throws, the
  acceptance rolls back and the link still works.

  Every dead invitation gets the same answer, byte for byte: unknown, expired, already
  accepted, revoked, tampered signature. The reason reaches your application through the
  `InvitationRejected` event and goes nowhere else — anything more specific in the
  response would answer "was this ever a real link".

  The `invitations` config block defaults to `enabled => false`, so nothing changes for an
  existing installation.

### Fixed

- **A magic link could be reported as unknown on a deployment with a read connection.**
  `claimLink()` now runs in a transaction, so every statement it issues uses the write
  connection.

  `Connection::getReadPdo()` returns the read connection unless a transaction is open,
  `sticky` is set after an earlier write, or the application forced read-on-write. Claiming
  a link satisfied none of those — it is usually the first database work of the request — so
  all four of its statements went to the replica: both lookups, the failure classification,
  and, on PostgreSQL, the atomic claim itself, which is the one driver that reaches
  `select()` rather than `update()`.

  The lookups are the quieter half and the likelier one to be seen: a link issued moments
  ago may not have replicated yet, so a valid link is rejected as unknown — intermittently,
  and only under replication lag. One-time codes were never affected; `claimCode()` has
  always run in a transaction.

  Nothing changes for a single-connection deployment, which is the default.

- **An application that sets `Date::use(CarbonImmutable::class)` could not mint at all.**
  `issueLink()` and `issueCode()` are now typed against `Carbon\CarbonInterface`, as is
  `MagicLinkToken::isExpired()`.

  The reach was wider than the signatures suggest. Eloquent's `datetime` cast resolves
  through the `Date` facade on every return path, so under that setting `$token->expires_at`
  is itself a `CarbonImmutable` — and this package fed exactly that value into `IssuedLink`
  and `IssuedCode`, which required the mutable `Illuminate\Support\Carbon`. The `TypeError`
  was therefore raised inside the package on a call that passes no date at all, not at the
  edge where a caller hands one in. Both entry points were unusable, not merely awkward.

  No class type could ever have covered both cases: `CarbonImmutable` does not extend
  `Illuminate\Support\Carbon`, and the two branches part further down still, at `DateTime`
  and `DateTimeImmutable`. `CarbonInterface` is the only surface that spans them, and both
  implement it.

  **What you get back has not changed.** Without `Date::use()` these values are the mutable
  `Illuminate\Support\Carbon` they have always been; a test pins that alongside the
  immutable case.

  Two consequences worth knowing before you upgrade:

  - **Type your own parameters against `CarbonInterface`.** Runtime behavior is unchanged,
    but code that passes `IssuedLink::$expiresAt` into a parameter typed as
    `Illuminate\Support\Carbon` will be flagged by your own static analysis, because the
    property is now declared wider than that.
  - **If you extend `MagicLinkToken` and override `isExpired()`**, widen your parameter to
    `?CarbonInterface` in the same upgrade. PHP forbids narrowing an inherited parameter, so
    an override still typed `?Carbon` is a fatal error at class-load time.
