### PR TITLE
Release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,82 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0] - 2026-08-23
+
+### Changed
+
+- **The resend countdown's script is now a same-origin file rather than an inline block.**
+  Inline, it needed a Content-Security-Policy nonce under any strict policy — and an
+  application whose policy issues no nonces had nothing it could pass through, so for those
+  hosts the countdown could not be made to run at all. Served from
+  `/magic-link/resend-countdown.js`, a plain `script-src 'self'` accepts it with no nonce and
+  no configuration.
+
+  It still carries the nonce when the application has one, and that is not redundancy: a
+  policy built on `'strict-dynamic'` ignores `'self'`, so there the nonce remains the only
+  thing that grants the tag.
+
+  No build step, no npm, no publishable assets and no `dist/` — the source is a constant in
+  `EmailMagicLink\Support\ResendCountdownScript`, so it is present the moment the package is
+  installed rather than the moment a host remembers to publish something. The URL carries a
+  digest of that source, which is what makes its immutable cache header honest: change the
+  script and the URL changes with it.
+
+  The tag is `defer`, so it no longer blocks the parse of the sign-in screen. Its response
+  is cached `private`, not `public`: the route runs inside your route middleware group, so
+  it leaves with the session and XSRF cookies attached like every other page, and a shared
+  cache that stores a response together with its `Set-Cookie` headers can hand one
+  visitor's session cookie to the next. The browser cache is where the benefit is anyway.
+
+- **The plain layout's inline stylesheet now carries the CSP nonce too.** The WireKit
+  layout has nonced its `<style>` block since the CSP work landed; the plain one had been
+  left out. The consequence is not subtle: under a strict policy that block is blocked, and
+  that block is the entire styling of the bundled screens — the sign-in page arrives
+  completely unstyled. The countdown script degrades politely when it is blocked. This does
+  not. Hosts without a policy render byte-identically.
+
+  The stylesheet stays **inline** rather than moving to a file the way the countdown script
+  did, and that is now a measured decision rather than an inherited default: the whole
+  sign-in screen fits inside one initial congestion window, so it paints in a single round
+  trip. A stylesheet in a file would cost a second, render-blocking round trip on a page
+  that is entirely above the fold. A test holds that threshold, so growing past it is a
+  notice rather than a silent regression.
+
+- **Looking at an invitation no longer spends the budget for accepting one.** The page that
+  displays an invitation was the only `GET` in the package carrying a throttle, and it drew
+  on the `consume` limiter — the same budget as the three routes that actually spend a
+  credential. Reloading the page therefore cost a real sign-in attempt, and because the
+  per-IP half of that limiter is shared, behind one egress address (an office, a carrier's
+  CGNAT, a school) one person reloading could lock another out.
+
+  It now has its own limiter, `limiters.invitation_view`
+  (`email-magic-link:invitation-view`), with its own `limits.invitation_view` default of 30
+  per minute — higher than `consume` because it guards a page load rather than a credential
+  being spent. The route stays throttled: unlike the sign-in confirmation it is not behind
+  `signed`, so its answer tells an unauthenticated caller whether a token exists.
+
+  Nothing to do on upgrade. Hosts that redefine the package limiters with
+  `RateLimiter::for()` can leave the new one alone and get the bundled definition; hosts
+  that want the old behavior can point `limiters.invitation_view` at their consume limiter.
+
+### Fixed
+
+- **A base URL without a scheme produced a link without one.** `issueLink()` and `invite()`
+  take an optional `baseUrl` so a link can be built for another host. Passed a bare host —
+  `tenant.example.com` or `//tenant.example.com` — the generator forced a root URL that
+  carried no scheme of its own, and the root then decided: the link came out as
+  `tenant.example.com/magic-link/verify/...`, absolute nowhere.
+
+  That string goes in an email, and mail clients disagree about it — some make a link, some
+  make none, some make a relative one. For an invitation it is the difference between working
+  and the invited person never getting in.
+
+  A schemeless base URL is now completed with the scheme the application itself is served
+  over, which is the one completion that invents nothing the host has not already stated. A
+  base URL that carries its own scheme is untouched, including a tenant on https while the
+  app runs on http. The signature is still computed over the final URL, so the completed link
+  verifies where it points.
+
 ## [0.21.0] - 2026-08-21
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "cweagans/composer-patches": "^1.7",
-        "larastan/larastan": "^3.0",
+        "larastan/larastan": "3.10.0",
         "laravel/fortify": "^1.0",
         "laravel/pao": "^1.1",
         "laravel/pint": "^1.0",
@@ -36,12 +36,12 @@
         "pestphp/pest-plugin-browser": "^5.0",
         "pestphp/pest-plugin-evals": "^5.0",
         "pestphp/pest-plugin-laravel": "^5.0",
-        "pestphp/pest-plugin-phpstan": "^5.0",
+        "pestphp/pest-plugin-phpstan": "5.1.0",
         "pestphp/pest-plugin-rector": "^5.0",
         "pestphp/pest-plugin-type-coverage": "^5.0",
         "pushery/wirekit": "^2.26",
-        "rector/rector": "^2.0",
-        "spaze/phpstan-disallowed-calls": "^4.12"
+        "rector/rector": "2.6.3",
+        "spaze/phpstan-disallowed-calls": "4.14.0"
     },
     "suggest": {
         "laravel/fortify": "Enables the no-bypass two-factor (TOTP) handoff: a magic-link user with confirmed 2FA completes Fortify's challenge before being logged in (^1.0).",

--- a/config/email-magic-link.php
+++ b/config/email-magic-link.php
@@ -339,22 +339,36 @@ return [
     | your application with RateLimiter::for() using the same names. The "limits"
     | defaults below are used by the bundled limiter definitions.
     |
-    | "request" covers ONE route (POST magic-link). "consume" covers FOUR, which
+    | "request" covers ONE route (POST magic-link). "consume" covers THREE, which
     | therefore share one budget: POST magic-link/verify/{token}, POST
-    | magic-link/code, and both invitation routes -- including the GET that only
-    | DISPLAYS an invitation, throttled deliberately because the token in its path
-    | is guessable-in-principle and the page confirms whether it exists.
+    | magic-link/code, and POST magic-link/invitation/{token}. All three SPEND a
+    | credential.
+    |
+    | "invitation_view" covers the one route that is throttled without spending
+    | anything: the GET that DISPLAYS an invitation. It is guarded because the token
+    | in its path is guessable-in-principle and the page confirms whether it exists --
+    | but out of its own budget, because merely looking at an invitation must not
+    | consume the allowance that accepting one needs. Behind a shared egress address
+    | (an office, a carrier's CGNAT, a school) the per-IP budget is shared by every
+    | user on it, so a page reloaded a few times would otherwise cost someone else
+    | their sign-in. Its default is correspondingly higher: a page load is cheap and
+    | a person may open the link more than once.
+    |
+    | The three other GET routes carry no limiter at all: they are forms, they carry
+    | no credential, and they spend nothing.
     |
     */
 
     'limiters' => [
         'request' => 'email-magic-link:request',
         'consume' => 'email-magic-link:consume',
+        'invitation_view' => 'email-magic-link:invitation-view',
     ],
 
     'limits' => [
         'request' => ['max' => 5, 'per_minutes' => 1],
         'consume' => ['max' => 10, 'per_minutes' => 1],
+        'invitation_view' => ['max' => 30, 'per_minutes' => 1],
     ],
 
     /*

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -5,7 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
     <title>@yield('title', __('email-magic-link::messages.sign_in')) &middot; {{ config('app.name') }}</title>
-    <style>
+
+    {{-- The application's per-response CSP nonce, or null when it has no policy.
+         The WireKit layout has noncing its inline <style> since the CSP work; this one
+         did not, and the omission is worth naming because the consequence is not subtle:
+         under a strict policy the block below is blocked, and the block below IS the
+         entire styling of these screens — the sign-in page arrives completely unstyled.
+         The countdown script degrades politely when it is blocked. This does not.
+
+         Same seam the countdown partial uses. --}}
+    @php($emlNonce = app(\EmailMagicLink\Contracts\ScriptNonce::class)->value())
+
+    {{-- An expression rather than @if: a Blade conditional inside a tag leaves its
+         whitespace behind, so the tag renders as `<style >`.
+
+         INLINE, not a file, and that was decided rather than inherited.
+         The countdown's script moved out of the page so a strict `script-src 'self'`
+         accepts it without a nonce, and the same argument appears to apply here. It does
+         not: this whole screen fits inside one initial congestion window, so it paints in
+         ONE round trip. A stylesheet in a file would cost a second one, render-blocking,
+         on a page that is entirely above the fold — to save bytes the browser has already
+         received. That is the standard treatment of critical CSS, and CriticalCssBudgetTest
+         holds the threshold the decision rests on. --}}
+    <style{!! $emlNonce === null ? '' : ' nonce="'.e($emlNonce).'"' !!}>
         :root { color-scheme: light dark; }
         body {
             margin: 0;

--- a/resources/views/partials/resend-countdown.blade.php
+++ b/resources/views/partials/resend-countdown.blade.php
@@ -3,14 +3,23 @@
      enhancement only: with JavaScript off the button stays usable and the
      server simply holds the next request back again.
 
-     The script carries the application's CSP nonce when there is one. Without
-     it, a strict policy blocks the script and the countdown never runs — and
-     "progressive enhancement" means it fails silently, so the user just meets a
-     rejection when they click too early. See the ScriptNonce contract. --}}
+     The script is an EXTERNAL same-origin file, not an inline block, and that is
+     a CSP decision rather than a tidiness one. Inline, it needed a nonce under any
+     strict policy — and a host whose policy issues no nonces had nothing to pass
+     through, so for them the countdown could not be made to run at all. A file
+     from the app's own origin satisfies `script-src 'self'` with no host action.
+
+     It still carries the nonce when there is one, and that is not belt-and-braces:
+     a policy built on 'strict-dynamic' IGNORES 'self', so under one the nonce is
+     the only thing that grants the tag. See the ScriptNonce contract. --}}
 @php($resendSeconds = (int) session('resend_retry_after'))
 @php($emlNonce = app(\EmailMagicLink\Contracts\ScriptNonce::class)->value())
 
 @if ($resendSeconds > 0)
+    {{-- Inside the conditional, not above it: this partial is included on every render
+         of the request screen and the countdown shows on almost none of them. --}}
+    @php($emlCountdownScript = route('email-magic-link.resend-countdown-script', ['v' => \EmailMagicLink\Support\ResendCountdownScript::version()]))
+
     {{-- role="timer", not role="status". A status region is aria-live="polite", so a
          value that changes every second is announced every second — a screen reader
          reader would hear the remaining time read out eight times instead of being
@@ -30,39 +39,9 @@
 
     {{-- An expression rather than @if: a Blade conditional inside a tag leaves its
          whitespace behind, so the tag renders as `<script >`. The nonce is escaped
-         because it arrives from a host implementation of the contract. --}}
-    <script{!! $emlNonce === null ? '' : ' nonce="'.e($emlNonce).'"' !!}>
-        (function () {
-            var el = document.querySelector('[data-eml-resend]');
+         because it arrives from a host implementation of the contract.
 
-            if (! el) {
-                return;
-            }
-
-            var form = (el.closest('main') || document).querySelector('form');
-            var button = form ? form.querySelector('button[type="submit"], button:not([type])') : null;
-            var template = el.getAttribute('data-template') || '';
-            var remaining = parseInt(el.getAttribute('data-seconds'), 10) || 0;
-
-            if (button) {
-                button.disabled = true;
-            }
-
-            (function tick() {
-                if (remaining <= 0) {
-                    if (button) {
-                        button.disabled = false;
-                    }
-
-                    el.textContent = '';
-
-                    return;
-                }
-
-                el.textContent = template.replace('__seconds__', remaining);
-                remaining -= 1;
-                window.setTimeout(tick, 1000);
-            })();
-        })();
-    </script>
+         `defer` because the script only touches the DOM and must not block the parse
+         of a sign-in screen for a progressive enhancement. --}}
+    <script src="{{ $emlCountdownScript }}" defer{!! $emlNonce === null ? '' : ' nonce="'.e($emlNonce).'"' !!}></script>
 @endif

--- a/routes/email-magic-link.php
+++ b/routes/email-magic-link.php
@@ -6,6 +6,7 @@ use EmailMagicLink\Http\Controllers\AcceptInvitationController;
 use EmailMagicLink\Http\Controllers\ConfirmMagicLinkController;
 use EmailMagicLink\Http\Controllers\ConsumeCodeController;
 use EmailMagicLink\Http\Controllers\ConsumeMagicLinkController;
+use EmailMagicLink\Http\Controllers\ResendCountdownScriptController;
 use EmailMagicLink\Http\Controllers\SendMagicLinkController;
 use EmailMagicLink\Http\Controllers\ShowCodeFormController;
 use EmailMagicLink\Http\Controllers\ShowInvitationController;
@@ -23,6 +24,7 @@ use Illuminate\Support\Facades\Route;
 $config = app(MagicLinkConfig::class);
 $requestLimiter = $config->requestLimiter();
 $consumeLimiter = $config->consumeLimiter();
+$invitationViewLimiter = $config->invitationViewLimiter();
 
 // All routes are registered whenever the channel is enabled; the configured
 // mode governs which one actually issues a token, not which routes exist.
@@ -45,6 +47,15 @@ Route::post('magic-link/verify/{token}', ConsumeMagicLinkController::class)
 Route::get('magic-link/code', ShowCodeFormController::class)
     ->name('email-magic-link.code.form');
 
+// The resend countdown's client script, served as a same-origin file so a strict
+// `script-src 'self'` accepts it with no nonce and no host action at all. Inline, it
+// was unreachable for a host whose policy issues no nonces: there was nothing to pass
+// through. Unthrottled and unsigned like the two form routes -- it carries no
+// credential, spends nothing, and its body is a constant. The URL carries a digest of
+// that constant, which is what makes the immutable cache header honest.
+Route::get('magic-link/resend-countdown.js', ResendCountdownScriptController::class)
+    ->name('email-magic-link.resend-countdown-script');
+
 Route::post('magic-link/code', ConsumeCodeController::class)
     ->middleware("throttle:{$consumeLimiter}")
     ->name('email-magic-link.code.consume');
@@ -60,8 +71,17 @@ if ($config->invitationsEnabled()) {
     //
     // Inert like the sign-in confirmation: only the POST spends the invitation, so a
     // scanner following the link cannot burn it.
+    //
+    // It is nevertheless the one GET in the package that carries a limiter, and that
+    // is deliberate rather than left over: unlike the sign-in confirmation it is not
+    // behind `signed`, so an unauthenticated caller can address it with any token it
+    // likes and the answer says whether that token exists.
+    //
+    // Its OWN limiter, though, not the consume one. Sharing that budget would mean
+    // looking at an invitation spends the allowance accepting it needs -- and behind
+    // one egress address, everyone else's sign-in too.
     Route::get('magic-link/invitation/{token}', ShowInvitationController::class)
-        ->middleware("throttle:{$consumeLimiter}")
+        ->middleware("throttle:{$invitationViewLimiter}")
         ->name('email-magic-link.invitation.show');
 
     Route::post('magic-link/invitation/{token}', AcceptInvitationController::class)

--- a/src/EmailMagicLinkServiceProvider.php
+++ b/src/EmailMagicLinkServiceProvider.php
@@ -330,6 +330,7 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
 
         RateLimiter::for($config->requestLimiter(), fn (Request $http): array => $limits->forRequest($http));
         RateLimiter::for($config->consumeLimiter(), fn (Request $http): array => $limits->forConsume($http));
+        RateLimiter::for($config->invitationViewLimiter(), fn (Request $http): array => $limits->forInvitationView($http));
     }
 
     private function registerPublishing(): void

--- a/src/Http/Controllers/ResendCountdownScriptController.php
+++ b/src/Http/Controllers/ResendCountdownScriptController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Controllers;
+
+use EmailMagicLink\Support\ResendCountdownScript;
+use Illuminate\Http\Response;
+
+/**
+ * Serves the resend countdown's client script as a same-origin file.
+ *
+ * A route rather than a published asset: a package that publishes assets is a
+ * package whose script is missing on every host that never ran the publish command,
+ * and the whole point of moving this out of the page is to make it work WITHOUT the
+ * host doing anything. There is no build step and no `dist/` -- see
+ * `ResendCountdownScript` for why the source sits in a constant.
+ *
+ * The response is cacheable forever because the URL carries a digest of the bytes:
+ * change the script and the URL changes with it.
+ */
+final class ResendCountdownScriptController
+{
+    public function __invoke(): Response
+    {
+        return new Response(ResendCountdownScript::contents(), 200, [
+            'Content-Type' => 'application/javascript; charset=utf-8',
+            // PRIVATE, not public, and that is a correctness point rather than a
+            // conservative default. This route runs inside the host's route middleware
+            // group -- `web` by default -- so the response leaves with a session cookie
+            // and an XSRF cookie attached, exactly like every other page of the package.
+            // `public` invites a shared cache to store it, and a shared cache that stores
+            // a response WITH its Set-Cookie headers can hand one visitor's session
+            // cookie to the next. Conformant caches strip it; "conformant" is not a thing
+            // an authentication package gets to assume about somebody else's proxy.
+            //
+            // `private` costs nothing here: the browser cache is where the benefit
+            // actually is, since the script is fetched once per visitor and the URL is
+            // versioned by content digest, so `immutable` still holds.
+            'Cache-Control' => 'private, max-age=31536000, immutable',
+            // The body is JavaScript and says so; without this a browser that
+            // sniffs could decide otherwise for a response it fetched as a script.
+            'X-Content-Type-Options' => 'nosniff',
+        ]);
+    }
+}

--- a/src/Support/MagicLinkConfig.php
+++ b/src/Support/MagicLinkConfig.php
@@ -504,6 +504,16 @@ final readonly class MagicLinkConfig
     }
 
     /**
+     * The limiter on the one route that is throttled without spending anything: the
+     * GET that displays an invitation. Separate from the consume limiter so viewing
+     * an invitation cannot use up the budget accepting one needs.
+     */
+    public function invitationViewLimiter(): string
+    {
+        return $this->string($this->config->get('email-magic-link.limiters.invitation_view'), 'email-magic-link:invitation-view');
+    }
+
+    /**
      * @return array{max: int, per_minutes: int}
      */
     public function requestLimit(): array
@@ -517,6 +527,17 @@ final readonly class MagicLinkConfig
     public function consumeLimit(): array
     {
         return $this->readLimit('consume', 10);
+    }
+
+    /**
+     * Higher than the consume default on purpose: this guards a page load, not a
+     * credential being spent, and a person may open their invitation more than once.
+     *
+     * @return array{max: int, per_minutes: int}
+     */
+    public function invitationViewLimit(): array
+    {
+        return $this->readLimit('invitation_view', 30);
     }
 
     public function resendEnabled(): bool

--- a/src/Support/RateLimits.php
+++ b/src/Support/RateLimits.php
@@ -8,10 +8,16 @@ use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 
 /**
- * Builds the named rate limiters for the request and consume endpoints.
+ * Builds the named rate limiters for the package's throttled endpoints.
  *
  * The request endpoint is throttled per email and per IP; the consume endpoint
- * per IP and per token (keyed by the token hash, never the raw token).
+ * per IP and per token (keyed by the token hash, never the raw token); the
+ * invitation display the same way as consume but out of its OWN budget.
+ *
+ * Every bucket prefix here is distinct (`eml:req:`, `eml:con:`, `eml:inv:`), and
+ * that is the whole point of the third one: a shared prefix is a shared budget,
+ * so viewing an invitation would spend the allowance accepting one needs -- and
+ * behind one egress address, everyone else's too.
  */
 final readonly class RateLimits
 {
@@ -38,16 +44,43 @@ final readonly class RateLimits
     public function forConsume(Request $request): array
     {
         $limit = $this->config->consumeLimit();
-        $token = $request->route('token');
-        $email = $request->input('email');
-
-        $discriminator = is_string($token) && $token !== ''
-            ? hash('sha256', $token)
-            : (is_string($email) ? mb_strtolower(trim($email)) : '');
 
         return [
             Limit::perMinutes($limit['per_minutes'], $limit['max'])->by('eml:con:ip:'.($request->ip())),
-            Limit::perMinutes($limit['per_minutes'], $limit['max'])->by('eml:con:id:'.$discriminator),
+            Limit::perMinutes($limit['per_minutes'], $limit['max'])->by('eml:con:id:'.$this->discriminator($request)),
         ];
+    }
+
+    /**
+     * The invitation display page. Same shape as consume, different budget.
+     *
+     * @return list<Limit>
+     */
+    public function forInvitationView(Request $request): array
+    {
+        $limit = $this->config->invitationViewLimit();
+
+        return [
+            Limit::perMinutes($limit['per_minutes'], $limit['max'])->by('eml:inv:ip:'.($request->ip())),
+            Limit::perMinutes($limit['per_minutes'], $limit['max'])->by('eml:inv:id:'.$this->discriminator($request)),
+        ];
+    }
+
+    /**
+     * The token in the path decides the bucket; the submitted email is the fallback
+     * only when there is no token, so a caller cannot pick a bucket by shortening the
+     * token in the URL. Never the raw token -- always its hash.
+     */
+    private function discriminator(Request $request): string
+    {
+        $token = $request->route('token');
+
+        if (is_string($token) && $token !== '') {
+            return hash('sha256', $token);
+        }
+
+        $email = $request->input('email');
+
+        return is_string($email) ? mb_strtolower(trim($email)) : '';
     }
 }

--- a/src/Support/ResendCountdownScript.php
+++ b/src/Support/ResendCountdownScript.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+/**
+ * The resend countdown's client script, and the version stamp its URL carries.
+ *
+ * It used to be an inline `<script>` in the partial, which meant a strict policy
+ * needed a nonce for it -- and a host whose policy issues NO nonces had nothing to
+ * pass through, so for them the countdown could not be made to run at all. An
+ * external same-origin file satisfies a plain `script-src 'self'` with no nonce and
+ * no host action, which is the reason for the move.
+ *
+ * WHY THE SOURCE LIVES IN A PHP CONSTANT rather than a `.js` file. This package
+ * deliberately has no client-asset path: no npm, no build step, no `dist/`, and no
+ * publishable assets, so `resources/` carries only `views/` and `boost/`. Every
+ * alternative reintroduces one of those, and each brings a way to be absent at
+ * runtime -- an unpublished asset, an unbuilt bundle, a host that never ran the
+ * publish command. A constant is in the package the moment the package is
+ * installed, which is the property that actually matters for something a strict
+ * policy is meant to make reliable.
+ *
+ * The script is static: every value it needs arrives through `data-` attributes on
+ * the element it drives, so nothing here is rendered per request and the file can
+ * be cached forever.
+ */
+final class ResendCountdownScript
+{
+    /**
+     * Progressive enhancement, and it degrades in the right direction: with the
+     * script blocked or absent the button stays usable and the server simply holds
+     * the next request back again.
+     */
+    private const string SOURCE = <<<'JS'
+        (function () {
+            var el = document.querySelector('[data-eml-resend]');
+
+            if (! el) {
+                return;
+            }
+
+            var form = (el.closest('main') || document).querySelector('form');
+            var button = form ? form.querySelector('button[type="submit"], button:not([type])') : null;
+            var template = el.getAttribute('data-template') || '';
+            var remaining = parseInt(el.getAttribute('data-seconds'), 10) || 0;
+
+            if (button) {
+                button.disabled = true;
+            }
+
+            (function tick() {
+                if (remaining <= 0) {
+                    if (button) {
+                        button.disabled = false;
+                    }
+
+                    el.textContent = '';
+
+                    return;
+                }
+
+                el.textContent = template.replace('__seconds__', remaining);
+                remaining -= 1;
+                window.setTimeout(tick, 1000);
+            })();
+        })();
+
+        JS;
+
+    public static function contents(): string
+    {
+        return self::SOURCE;
+    }
+
+    /**
+     * A short digest of the source, carried in the URL as `?v=`.
+     *
+     * This is what lets the response be cached immutably: the bytes and the URL move
+     * together, so a changed script is a changed URL and no browser can be left
+     * holding the old one. Not a security boundary -- a cache key -- which is why a
+     * truncated digest is enough.
+     *
+     * Memoised because the input is a compile-time constant: the answer cannot change
+     * within a process, and this is called from a view.
+     */
+    public static function version(): string
+    {
+        return self::$version ??= substr(hash('sha256', self::SOURCE), 0, 12);
+    }
+
+    private static ?string $version = null;
+}

--- a/src/Support/SignedTokenUrl.php
+++ b/src/Support/SignedTokenUrl.php
@@ -20,10 +20,23 @@ use Illuminate\Support\Facades\URL;
 final class SignedTokenUrl
 {
     /**
+     * Matches an RFC 3986 scheme followed by the authority marker.
+     *
+     * `parse_url()` is not used for this test. It reads `localhost:8080` as a host
+     * and a port on some inputs and as a scheme and a path on others, so "does this
+     * string carry a scheme" is exactly the question it answers inconsistently.
+     * Requiring `://` is the right question here anyway: a base URL is an origin, and
+     * an origin without an authority is not one.
+     */
+    private const string SCHEME_PATTERN = '#^([a-zA-Z][a-zA-Z0-9+.\-]*)://#';
+
+    /**
      * @param  string|null  $baseUrl  Override the host the URL is built for (e.g. a
      *                                tenant domain). The signature is computed over
      *                                that final host, so the URL verifies only when
-     *                                visited there -- never an attacker's.
+     *                                visited there -- never an attacker's. A base URL
+     *                                with no scheme is completed with the application's
+     *                                own; see `absolute()`.
      */
     public static function for(string $routeName, CarbonInterface $expiresAt, string $plaintext, ?string $baseUrl = null): string
     {
@@ -31,12 +44,14 @@ final class SignedTokenUrl
             return self::sign($routeName, $expiresAt, $plaintext);
         }
 
+        [$baseUrl, $scheme] = self::absolute($baseUrl);
+
         // Force the host AND scheme from the base URL for this one signing call,
         // then restore both so no later URL generation in the request inherits
         // the tenant host. Forcing the scheme too makes an https base URL sign as
         // https even when the app itself is served over http.
         URL::forceRootUrl($baseUrl);
-        URL::forceScheme(parse_url($baseUrl, PHP_URL_SCHEME) ?: '');
+        URL::forceScheme($scheme);
 
         try {
             return self::sign($routeName, $expiresAt, $plaintext);
@@ -44,6 +59,41 @@ final class SignedTokenUrl
             URL::forceRootUrl(null);
             URL::forceScheme('');
         }
+    }
+
+    /**
+     * Completes a base URL that carries no scheme with the application's own.
+     *
+     * A bare host used to travel straight through: `forceRootUrl('//tenant.test')`
+     * holds a root with no scheme of its own, the root then decides, and the link
+     * came out as `tenant.test/magic-link/...`. Defensible for a caller that
+     * deliberately passed a bare host -- and poor for the place these links actually
+     * go, which is an email. A mail client turns a schemeless string into a link,
+     * into no link, or into a relative one, depending on the client; for an
+     * invitation that is the difference between "works" and "the invited person
+     * never gets in".
+     *
+     * The application's scheme is the one completion that invents nothing a host has
+     * not already stated: it is what every other URL the app emits already uses. A
+     * base URL that does carry a scheme is returned untouched, tenant scheme and all.
+     *
+     * @return array{0: string, 1: string} the absolute base URL and its scheme
+     */
+    private static function absolute(string $baseUrl): array
+    {
+        if (preg_match(self::SCHEME_PATTERN, $baseUrl, $matches) === 1) {
+            return [$baseUrl, $matches[1]];
+        }
+
+        // `formatScheme()` rather than parsing `url('/')`: it is typed to return a
+        // string, it honours a host that has called `forceScheme()` behind a proxy,
+        // and in the console it reads the request Laravel builds from `app.url`. It
+        // yields the scheme with its separator, e.g. `https://`.
+        $scheme = rtrim(URL::formatScheme(), ':/');
+
+        // Both schemeless forms reach here -- `//tenant.test` and `tenant.test` --
+        // and both mean the same host.
+        return [$scheme.'://'.ltrim($baseUrl, '/'), $scheme];
     }
 
     private static function sign(string $routeName, CarbonInterface $expiresAt, string $plaintext): string


### PR DESCRIPTION

### Changed

- **The resend countdown's script is now a same-origin file rather than an inline block.**
  Inline, it needed a Content-Security-Policy nonce under any strict policy — and an
  application whose policy issues no nonces had nothing it could pass through, so for those
  hosts the countdown could not be made to run at all. Served from
  `/magic-link/resend-countdown.js`, a plain `script-src 'self'` accepts it with no nonce and
  no configuration.

  It still carries the nonce when the application has one, and that is not redundancy: a
  policy built on `'strict-dynamic'` ignores `'self'`, so there the nonce remains the only
  thing that grants the tag.

  No build step, no npm, no publishable assets and no `dist/` — the source is a constant in
  `EmailMagicLink\Support\ResendCountdownScript`, so it is present the moment the package is
  installed rather than the moment a host remembers to publish something. The URL carries a
  digest of that source, which is what makes its immutable cache header honest: change the
  script and the URL changes with it.

  The tag is `defer`, so it no longer blocks the parse of the sign-in screen. Its response
  is cached `private`, not `public`: the route runs inside your route middleware group, so
  it leaves with the session and XSRF cookies attached like every other page, and a shared
  cache that stores a response together with its `Set-Cookie` headers can hand one
  visitor's session cookie to the next. The browser cache is where the benefit is anyway.

- **The plain layout's inline stylesheet now carries the CSP nonce too.** The WireKit
  layout has nonced its `<style>` block since the CSP work landed; the plain one had been
  left out. The consequence is not subtle: under a strict policy that block is blocked, and
  that block is the entire styling of the bundled screens — the sign-in page arrives
  completely unstyled. The countdown script degrades politely when it is blocked. This does
  not. Hosts without a policy render byte-identically.

  The stylesheet stays **inline** rather than moving to a file the way the countdown script
  did, and that is now a measured decision rather than an inherited default: the whole
  sign-in screen fits inside one initial congestion window, so it paints in a single round
  trip. A stylesheet in a file would cost a second, render-blocking round trip on a page
  that is entirely above the fold. A test holds that threshold, so growing past it is a
  notice rather than a silent regression.

- **Looking at an invitation no longer spends the budget for accepting one.** The page that
  displays an invitation was the only `GET` in the package carrying a throttle, and it drew
  on the `consume` limiter — the same budget as the three routes that actually spend a
  credential. Reloading the page therefore cost a real sign-in attempt, and because the
  per-IP half of that limiter is shared, behind one egress address (an office, a carrier's
  CGNAT, a school) one person reloading could lock another out.

  It now has its own limiter, `limiters.invitation_view`
  (`email-magic-link:invitation-view`), with its own `limits.invitation_view` default of 30
  per minute — higher than `consume` because it guards a page load rather than a credential
  being spent. The route stays throttled: unlike the sign-in confirmation it is not behind
  `signed`, so its answer tells an unauthenticated caller whether a token exists.

  Nothing to do on upgrade. Hosts that redefine the package limiters with
  `RateLimiter::for()` can leave the new one alone and get the bundled definition; hosts
  that want the old behavior can point `limiters.invitation_view` at their consume limiter.

### Fixed

- **A base URL without a scheme produced a link without one.** `issueLink()` and `invite()`
  take an optional `baseUrl` so a link can be built for another host. Passed a bare host —
  `tenant.example.com` or `//tenant.example.com` — the generator forced a root URL that
  carried no scheme of its own, and the root then decided: the link came out as
  `tenant.example.com/magic-link/verify/...`, absolute nowhere.

  That string goes in an email, and mail clients disagree about it — some make a link, some
  make none, some make a relative one. For an invitation it is the difference between working
  and the invited person never getting in.

  A schemeless base URL is now completed with the scheme the application itself is served
  over, which is the one completion that invents nothing the host has not already stated. A
  base URL that carries its own scheme is untouched, including a tenant on https while the
  app runs on http. The signature is still computed over the final URL, so the completed link
  verifies where it points.
