### PR TITLE
Release v0.24.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,7 +37,7 @@ body:
     id: package-version
     attributes:
       label: Package version
-      placeholder: e.g. v0.13.1
+      placeholder: e.g. the output of `composer show pushery/email-magic-link-for-laravel`
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,251 @@ All notable changes to this package are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0] - 2026-09-04
+
+### Added
+
+- **`email-magic-link:doctor` reports where the host of an emailed link comes from.** Laravel
+  builds every URL from a forced origin when one is set and from the request's `Host` header
+  otherwise, and on a server that answers any host a forged header lands in the email. The
+  command names which of the three the application is on: a forced origin, hosts restricted by
+  the `TrustHosts` middleware, or the request as it came in -- and only the last needs
+  attention. The security model page explains the two remedies.
+
+- **Every response on the package's routes carries `X-Robots-Tag: noindex, nofollow`.** The
+  bundled layouts have said so in a meta tag all along, but the host's invitation acceptance
+  view, a host-supplied invalid view, a custom responder and the countdown script never render
+  those layouts. The header covers what the body cannot, and it is attached outside the
+  `routes.middleware` key so an override cannot drop it.
+
+- **`MagicLinkRequestRefused` fires when the request endpoint refuses to issue anything:**
+  the captcha failed, or the resend guard held the address back (cooldown or rolling cap,
+  with the decision that says how long). The consume side always reported its failures
+  through `MagicLinkConsumptionFailed`; the request side had no counterpart, so a flood
+  against the request form — unknown addresses included — was invisible to a host's
+  alerting. The response stays generic. The framework's own `throttle:` limiter answers
+  429 before the controller runs and carries no event; the events page says what to
+  listen to for that one.
+
+- **`php artisan about` shows an `Email Magic Link` section:** whether the package is
+  enabled, the delivery mode, the state of the Fortify bridge and whether invitations are on.
+  Registered before the master switch, so a disabled package shows as disabled rather than
+  not at all.
+
+### Changed
+
+- **An invalid or expired link rendered as a view now answers with `abort_status` (403 by
+  default) instead of 200.** Every other strategy already answered with an error status; the
+  `view` strategy alone rendered the refusal as a success, which a link checker, an HTTP cache
+  and a crawler all read as one -- on the invitation page, at a URL that carries the token.
+  The same key governs both the `abort` and the `view` strategy now.
+
+- **The page title separator is `»` rather than `·`**, so the sign-in tab reads like the rest
+  of an application that follows the same convention: `Sign in » Acme`.
+
+- **On the code screen a wrong code is reported on the code field.** The generic failure was
+  keyed on `email` for every form, so the code screen marked the (correct, prefilled) email
+  address as invalid and left the code boxes untouched; screen readers were told the wrong
+  field was wrong. The response stays byte-identical for an unknown address and a wrong code.
+
+- **The purge deletes in chunks (`prune.chunk`, 1000 rows by default), and the command is
+  `Isolatable`.** One unbounded `DELETE` over months of rows held every row lock until commit
+  and stalled the sign-ins running beside it; `--isolated` now refuses a second copy while
+  one runs, for hosts that schedule the command themselves. The self-registered schedule
+  entry carries a name and a description, so `schedule:list` reads.
+
+- **The token models hide their hashes when serialized.** `passphrase_hash` is a bcrypt of a
+  human-chosen secret, and the models are exposed on public value objects.
+
+- **The package requires `laravel/framework ^13.23`.** The previous floor, `^13.0`, was a
+  promise no test could keep: the development toolchain cannot install anything below
+  13.23, so versions 13.0 to 13.22 were declared and never exercised. The new floor is the
+  lowest version the suite actually runs on.
+
+- **A click on a revoked or superseded invitation is reported as `ClaimFailure::Revoked`, not as
+  `AlreadyConsumed`.** The two were folded together, so a host alerting on "somebody used a
+  link an administrator withdrew" -- the one refusal that is a signal rather than noise --
+  could not tell it from a re-click on an accepted one. The visitor still sees the generic
+  refusal. A `match` over `ClaimFailure` without a default arm now has one more case to name.
+
+- **After requesting a code, the address reaches the code screen through the session, not
+  the query string.** `/magic-link/code?email=…` put every address into access logs, proxy
+  logs, browser history and the `Referer` of every asset the screen loads; the retry path
+  already avoided that. The code form no longer reads `?email=` at all, so a crafted link
+  cannot prefill a stranger's address either.
+
+### Fixed
+
+- **A table prefix on the database connection broke every claim.** The migrations, the
+  models and the query builder all honor a connection's `prefix`, so on a prefixed
+  connection the tables were created and written as `app_magic_link_tokens`. The one
+  statement that spends a link, a code or an invitation spelled the table name as a
+  literal in raw SQL and ran against a table that did not exist: links and codes were sent,
+  and every click and every code entry ended in a database error. The table name is now
+  built through the connection's grammar, prefix and quoting included.
+
+- **Building a link for another host erased the origin and scheme the application had
+  forced.** `issueLink()` and `invite()` accept a `baseUrl` for a tenant domain. To sign
+  against it, the generator forced that origin on the application's shared URL generator
+  and then "restored" it by forcing null -- which is a reset, not a restore. An application
+  that forces `https` behind a TLS-terminating proxy, or pins its origin, lost both the
+  moment one tenant link was minted, and every URL generated afterwards in that process
+  came out against the raw request: `http://` on an https host, signed URLs that fail on
+  arrival, and under a queue worker or Octane for every later request too. Tenant links
+  are now signed on a generator of their own, and the shared one is never written to.
+
+- **The sign-in mail was rendered in the queue worker's language, not the requester's.** The
+  notification is queued, and a worker renders it later under its own locale unless the
+  request's travels with it; nothing set it. Every application that switches the locale per
+  request and runs a queue worker sent the magic-link and code mails in the default language
+  -- and a synchronous queue, the usual development setup, never showed it. The request's
+  locale is now carried on the notification, which is the first place the sender looks.
+
+- **Two pages ahead of a claim still read from the replica.** On a deployment with separate
+  read and write connections, the confirm page asks whether a link wants a passphrase and the
+  invitation page asks whether the invitation is live -- each in a request of its own, after
+  the one that wrote the row. Both lookups went to the read connection, so while the replica
+  lagged, a passphrase-gated link rendered without its passphrase field and then failed on
+  submit, and a fresh, valid invitation was refused. The earlier fix that pinned the claim
+  itself to the primary did not cover these two readers; they are pinned now.
+
+- **A user with two-factor authentication enabled could sign in with a magic link and no
+  second factor, on any application where Fortify's `confirm` option is off.** Fortify's
+  shipped configuration registers the feature without that option, and then its own verdict
+  for "has two-factor enabled" is a stored secret alone; `two_factor_confirmed_at` is never
+  written. The handoff re-derived the verdict from that column, so it challenged nobody on
+  those applications while Fortify's password login challenged everyone. The handoff now
+  asks Fortify's own `hasEnabledTwoFactorAuthentication()`, so the magic link challenges
+  exactly the users the password form challenges: with `confirm` on, a secret and a
+  confirmation, which still keeps a user mid-setup out of the challenge; with `confirm`
+  off, a secret alone.
+
+- **Publishing the migrations and running `migrate` failed on a fresh database.** The
+  published copies get a fresh date prefix, so by name they were four other migrations for
+  the same tables, and the bundled files were still loaded beside them: the first `CREATE`
+  succeeded and the second died with "table already exists", a message that names the table
+  and not the cause. Once a published `*_create_magic_link_tokens_table.php` exists the
+  package no longer loads its bundled copies. A host that renames the published file says so
+  with `EmailMagicLinkServiceProvider::ignoreMigrations()`, which the installer and the
+  documentation now name.
+
+- **The WireKit screens had no level-one heading.** The kit's heading component defaults to
+  level two, and the three views passed no level, so a person navigating by headings landed
+  on nothing at level one -- on the sign-in pages, where nobody knows the layout yet. The
+  plain Blade screens always had an `h1`; the WireKit ones now do too.
+
+- **The document's `lang` attribute named the requested locale even when the page spoke the
+  fallback language.** On a locale the package has no bundle for, the strings fall back to
+  English while `lang` still said, say, `ja`, which sends a screen reader to the wrong voice.
+  The attribute now names the language the page actually renders in.
+
+- **A refused sign-in no longer writes the passphrase, or the acceptance form's password
+  fields, into the session.** The redirect after a refusal flashes the input so the form can
+  re-prefill; it excluded the one-time code and kept everything else, so a wrong passphrase
+  and, on the invitation form, `password` and `password_confirmation` landed in the session
+  store in the clear. Only the email and the guard are flashed now, as an allowlist.
+- **An array where the passphrase should be is treated as no passphrase.** `passphrase[]=a`
+  used to be a server error before the claim ran.
+
+- **The plain Blade button was 4.2:1 on the browser's default accent color and the error
+  text 2.55:1 in the dark scheme.** The button now paints `CanvasText` on `Canvas` (21:1
+  light, 17:1 dark) and the error color switches with the scheme (8.1:1 on the dark canvas).
+- **Plain Blade errors are associated with their field.** The field carries `aria-invalid`
+  and `aria-describedby` pointing at the message, so a screen reader that lands in the
+  autofocused field after a failed submit hears why. The code field also gets a numeric
+  keyboard for a digit-only alphabet, and capitals without spell-check for a letter one.
+- **The resend hold-back is one message, not two, and the button stays reachable.** The
+  request form showed a static "Please wait 30 seconds" beside a timer counting down, and
+  the static copy outlived the timer. Only the countdown renders now, inside the form and
+  before the button; the button is `aria-disabled` with the countdown as its description
+  rather than removed from the tab order, and it is released when the wait ends.
+
+- **The delivery-channel choice survives a failed submit.** A person who picked the one-time
+  code, mistyped the address and corrected it received a magic link: the radios never read
+  the previous choice back. Both render paths keep it now.
+- **The WireKit layout no longer overrides the kit's `color-scheme`.** WireKit declares its
+  own since 2.29.0; the layout's `light dark` won and painted native widgets dark on a page
+  whose tokens stayed light.
+
+- **`invalid_response.abort_status` is bounded to an error status.** A value outside 400
+  to 599 falls back to 403; before, 200 made the refusal a success and 0 or 999 a server
+  error the moment it was rendered.
+- **`link_ttl` and `code_ttl` follow the same integer rule as `ttl`.** A float was truncated
+  by the one and rejected by the other; both now accept an integer or a numeric string and
+  nothing else.
+- **`fortify.mode` accepts every boolean spelling the other switches accept.** `0`, `off`
+  and `no` disable the bridge; they used to leave it in `auto`, the one value the setting was
+  written to leave.
+
+- **A link or code whose guard has since been removed from `guards` no longer signs in.** The
+  guard was validated only when the token was issued, so an operator closing magic-link
+  sign-in on a guard still had every outstanding link honored for its lifetime.
+
+- **The regional bundles answer to the ISO 15897 spelling too.** Laravel's documentation
+  prescribes `pt_BR`, `pt_PT`, `en_GB` and `en_US`; the package shipped the hyphenated
+  directories only, and an application on the documented spelling silently fell back to
+  its fallback locale. Both spellings resolve now.
+
+- **A cache store that cannot hand out the resend lock in time now holds the request back
+  instead of answering with a server error.** The guard's lock timeout was never handled, so
+  a stalled Redis or a database under contention turned the request endpoint into a 500.
+
+- **The plain Blade passphrase field was unstyled** — the browser default, 153×21 px at
+  13 px, beside a 16 px email field, and small enough that iOS zooms on focus. It now
+  shares the input rule. On touch pointers the plain screens gain the same 44 px floors
+  the WireKit path has (inputs, button, radio rows), the sign-in link on the invalid page
+  is a button rather than an 18 px text link, and both layouts size the body with `dvh`
+  so iOS Safari centers the card in the visible viewport.
+
+- **`RateLimits::define()` registers the named limiters on the container's `RateLimiter`, not
+  on the facade's cached copy.** The documented repair for a per-tenant cache swap --
+  `forgetInstance()` then `define()` -- only worked when the host also cleared the facade,
+  which nothing said. Without that, the limiters landed on the discarded object while the
+  throttle middleware received the new, empty one, and every throttled route answered
+  `500 Rate limiter [email-magic-link:request] is not defined.`
+
+- **Every address is normalized the same way, and the normalization strips what `trim()`
+  leaves in place.** Lookups, limiter keys and resend keys all lowercased and trimmed by hand
+  in five places; they now share one helper built on `Str::trim()`, so a pasted address
+  carrying a no-break space, a zero-width space or a byte-order mark keys the same bucket
+  as the address typed by hand.
+
+- **A link token that matches nothing costs one statement, not three.** The claim ran its
+  atomic `UPDATE` and a third `SELECT` for a hash the first `SELECT` had already proved
+  absent -- the path every scanner takes.
+
+- **`InvitationAccepted` implements `ShouldDispatchAfterCommit`.** Its docblock promised
+  "after the transaction commits", and the dispatch site kept that promise for the package's
+  own transaction only; under a transaction the host opened around the request -- a
+  transactional middleware, a test -- listeners ran before the commit. The interface makes the
+  promise hold in both cases and costs nothing when no transaction is open.
+
+- **The sign-in mail greets and signs off from the package's own catalog** (`mail_greeting`,
+  `mail_salutation`, shipped in every bundled locale). The frame around the body -- `Hello!`,
+  `Regards,` -- came from the host's JSON catalog, which most non-English hosts never
+  translated, so a German body sat between English lines in a document that declared itself
+  German.
+
+### Documentation
+
+- The translations page said WireKit ships only German and used French as its example of a
+  locale to copy the English catalog for; WireKit has shipped French, Spanish, Italian, Dutch
+  and Portuguese since 2.27.0, and following the page overwrote them with English. The page now
+  lists the shipped set and uses a locale neither package ships as its example.
+- The response strategies for an invalid link carry their HTTP status in the configuration
+  guide, and the security model page explains where the host in an emailed link comes from.
+
+- The Boost skill now covers invitations, the multi-tenancy limiter re-definition and the
+  countdown route; the route tables list the countdown script; the contract reference has
+  the three invitation contracts and says how the shipped lookup compares addresses; the
+  configuration reference has an Invitations section and the deep-merge rule is on the
+  configuration guide; the events page's example runs as pasted and warns against logging a
+  request URL that is a token; the token-cleanup and multi-tenancy guides say what the
+  scheduled purge cannot do under tenancy and how to give it a heartbeat; the WireKit page
+  names Livewire's CSP build as the lever; the resend-guard page says the state is a cache
+  entry; the landing page states the browser support; CONTRIBUTING names Pest 5, the MySQL
+  suite and what CI really runs; and the changelog carries compare links for every version.
+
 ## [0.23.0] - 2026-08-27
 
 ### Added
@@ -225,17 +470,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - **Development only — nothing changes for an application that installs this package.**
-  The `test:coverage`, `mutate` and `mutate:detect` composer scripts now run through
-  `@php -d pcov.directory=.`.
-
-  pcov collects coverage only within its own directory scope, and with that scope unset it
-  reaches neither `config/` nor `database/`. Both therefore reported 0.0% while the suite
-  had been widened to certify everything the package ships; with the scope set they report
-  100%. The two halves only work together, which is why the scripts moved with it.
-
-  These scripts are run by this package's own contributors, never by the applications that
-  require it, so upgrading from 0.20.1 is a no-op at runtime. Everything else on this
-  release line is tests, continuous-integration lanes and tooling, none of which ship.
+  The `test:coverage`, `mutate` and `mutate:detect` composer scripts now pass
+  `-d pcov.directory=.`, so `config/` and `database/` are measured when contributors run them.
 
 ## [0.20.1] - 2026-08-04
 
@@ -350,7 +586,7 @@ public repository sees the difference.
   8.1, which requires it. `CONTRIBUTING.md` says so, and names the confusing symptom: on
   exactly 8.4.0 `composer install` fails citing `symfony/process`, never Pest.
 - `composer.json` gains a `test:evals` script and drops the finite `process-timeout` in
-  favour of `0`. Both are development-side only; no runtime dependency, autoload entry or
+  favor of `0`. Both are development-side only; no runtime dependency, autoload entry or
   published default moved.
 
 ## [0.19.0] - 2026-07-26
@@ -815,3 +1051,39 @@ public repository sees the difference.
   observability events (`MagicLinkRequested`, `MagicLinkVerified`,
   `TwoFactorChallengeRequired`).
 - Publishable configuration, migration, and views.
+
+[Unreleased]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.23.0...v0.24.0
+[0.23.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.22.0...v0.23.0
+[0.22.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.21.0...v0.22.0
+[0.21.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.20.2...v0.21.0
+[0.20.2]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.20.1...v0.20.2
+[0.20.1]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.20.0...v0.20.1
+[0.20.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.19.0...v0.20.0
+[0.19.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.18.0...v0.19.0
+[0.18.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.17.1...v0.18.0
+[0.17.1]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.17.0...v0.17.1
+[0.17.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.16.1...v0.17.0
+[0.16.1]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.16.0...v0.16.1
+[0.16.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.15.2...v0.16.0
+[0.15.2]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.15.1...v0.15.2
+[0.15.1]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.15.0...v0.15.1
+[0.15.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.13.3...v0.14.0
+[0.13.3]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.13.2...v0.13.3
+[0.13.2]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.13.1...v0.13.2
+[0.13.1]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.13.0...v0.13.1
+[0.13.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/pushery/email-magic-link-for-laravel/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/pushery/email-magic-link-for-laravel/releases/tag/v0.1.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,15 +39,19 @@ which runs, and each can be run on its own:
 | `composer analyse` | Static analysis — Larastan at `max` level, no errors. |
 | `composer test:type-coverage` | 100% type coverage of `src/`. |
 | `composer test:coverage` | 100% line coverage of `src/`. |
-| `composer mutate` | Mutation testing (see below). |
+
+`composer mutate` (see below) is **not** part of `qa`; it runs separately.
 
 ### Tests
 
 The suite uses [Pest](https://pestphp.com) and Orchestra Testbench. The defining axis is
 **Fortify present versus absent**: the `Integration` suite boots Fortify, while the
 `Unit` and `Feature` suites run the core in isolation and must never reference a Fortify
-symbol. CI exercises both axes across PHP 8.4/8.5, the lowest and highest dependency
-resolutions, and with and without Fortify.
+symbol. CI (the self-hosted Woodpecker gate) runs the suite on PHP 8.4 with `prefer-stable`
+and Fortify installed, against real PostgreSQL 18 and MySQL 8.4 at 100 % line and type
+coverage; a weekly lane repeats it with `prefer-lowest`. The PHP 8.4/8.5 × prefer-lowest/stable
+× with/without-Fortify matrix in `.github/workflows/tests.yml` is a disabled, manual-only
+workflow — run it before a release that changes the dependency floor.
 
 The `Postgres` suite verifies the `RETURNING`-based atomic claim against a real
 PostgreSQL connection. It is skipped automatically when Postgres is unavailable; to run
@@ -55,10 +59,17 @@ it locally, provide a database and set `PG_TEST_HOST`, `PG_TEST_PORT`, `PG_TEST_
 `PG_TEST_USER`, and `PG_TEST_PASSWORD` as needed (defaults target
 `127.0.0.1:5432` / `email_magic_link_test` / `postgres`).
 
+The `MySql` suite does the same against a real MySQL 8.4 connection (MariaDB is rejected, not
+supported — it clears the version floor numerically and is refused by identity). It reads
+`MYSQL_TEST_HOST`, `MYSQL_TEST_PORT`, `MYSQL_TEST_DB`, `MYSQL_TEST_USER` and
+`MYSQL_TEST_PASSWORD` (defaults `127.0.0.1:3308` / `email_magic_link_test` / `root`). Set
+`REQUIRE_DB_TESTS=1` to turn "skipped when unavailable" into a hard failure, which is how CI
+runs both suites.
+
 ### Mutation testing
 
-Mutation testing runs through Pest 4's built-in mutation plugin (Infection does not
-support Pest 4's function-style tests). It is not a gate — nothing refuses a release over
+Mutation testing runs through Pest 5's built-in mutation plugin (Infection doesn't support
+Pest's function-style tests). It isn't a gate: nothing refuses a release over
 the score, and the CI lane runs without a floor at all so a measurement is always recorded.
 What the local `composer mutate` enforces is an overall mutation score indicator of at
 least 93%, taken from the last serial run rather than chosen; the security-critical paths

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Passwordless email authentication for Laravel — magic links and one-time codes
 
 Plenty of packages send a magic link. This one is built around two properties most of them get wrong:
 
-- **A correct, no-bypass Fortify two-factor handoff.** A user with confirmed TOTP is handed to Fortify's own challenge in a not-yet-authenticated state; the login completes inside Fortify only after the code is verified. There is no path that signs a two-factor user in without the second factor.
+- **A correct, no-bypass Fortify two-factor handoff.** A user with two-factor authentication enabled is handed to Fortify's own challenge in a not-yet-authenticated state; the login completes inside Fortify only after the code is verified. There is no path that signs a two-factor user in without the second factor.
 - **Scanner-safe and prefetch-safe link consumption.** The emailed link is a signed, inert `GET` that only renders a confirmation page. The single-use token is spent solely by an explicit `POST`, so SafeLinks, Mimecast, Proofpoint and browser prefetch cannot burn the link before the human clicks "Sign in".
 
 ## Installation
@@ -33,7 +33,7 @@ Plenty of packages send a magic link. This one is built around two properties mo
 composer require pushery/email-magic-link-for-laravel
 ```
 
-Requires PHP `^8.4` and Laravel `^13.0`. Laravel Fortify (`^1.0`) is optional and only needed for the two-factor handoff. There are no third-party runtime dependencies.
+Requires PHP `^8.4` and Laravel `^13.23`. Laravel Fortify (`^1.0`) is optional and only needed for the two-factor handoff. There are no third-party runtime dependencies.
 
 ## Documentation
 
@@ -48,7 +48,7 @@ Requires PHP `^8.4` and Laravel `^13.0`. Laravel Fortify (`^1.0`) is optional an
 ## What it does
 
 - **Magic links and one-time codes** — pick either, or offer both.
-- **A complete browser flow out of the box** — six routes, the screens, and the emails; point your "log in" link at one route name.
+- **A complete browser flow out of the box** — the routes, the screens, and the emails; point your "log in" link at one route name.
 - **A Mint API** — issue a signed link or a code and get it back without sending anything, to deliver over any channel you like.
 - **Bounded multi-use links** — hand out a link redeemable N times, with the counter decremented in the same conditional `UPDATE` that consumes it, so concurrent redemptions can never exceed the limit.
 - **Passphrase-gated links** — require a shared secret, delivered out of band, before a high-value link is consumed.
@@ -56,8 +56,8 @@ Requires PHP `^8.4` and Laravel `^13.0`. Laravel Fortify (`^1.0`) is optional an
 - **Invitations** — the other half of the story. A magic link can only sign in somebody who already exists; an invitation puts an account *into service* for an address that has none yet. The package issues the token, supersedes the previous one when you re-invite, refuses every dead one identically, and spends it exactly once — your application decides what accepting one means.
 - **A JSON contract** — stable statuses and error codes for first-party SPA and mobile clients.
 - **Multiple guards** — sign in to an `admin` guard alongside `web`, on an allowlist that keeps guards un-enumerable.
-- **Eleven bundled locales** — English, German, Spanish, French, Italian, Dutch and Portuguese, plus the `en-GB`, `en-US`, `pt-PT` and `pt-BR` regional variants.
-- **Styled screens, or none of ours** — the sign-in views render with [WireKit](https://wirekit.app) when it is installed, fall back to dependency-free Blade when it is not, and can be published and rewritten either way.
+- **Bundled locales** — English, German, Spanish, French, Italian, Dutch and Portuguese, plus the `en-GB`, `en-US`, `pt-PT` and `pt-BR` regional variants under both spellings.
+- **Styled screens, or none of ours** — the sign-in views render with [WireKit](https://wirekit.app) when it is installed, fall back to dependency-free Blade when it is not, and can be published and rewritten either way. Browser support follows WireKit's floor on the styled path and the browser's own defaults on the plain one; see the [documentation](https://docs.pushery.com/email-magic-link-for-laravel/#browser-support).
 - **Designed to fail closed** — tokens hashed at rest, nothing serialized into a token, a single race-free conditional claim, and responses that never reveal whether an account exists.
 
 ## Built by PUSHERY

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.4",
         "ext-json": "*",
-        "laravel/framework": "^13.0"
+        "laravel/framework": "^13.23"
     },
     "require-dev": {
         "cweagans/composer-patches": "^1.7",
@@ -37,7 +37,8 @@
         "pestphp/pest-plugin-evals": "^5.0",
         "pestphp/pest-plugin-laravel": "^5.0",
         "pestphp/pest-plugin-phpstan": "5.2.0",
-        "pestphp/pest-plugin-rector": "^5.0",
+        "phpstan/phpstan": "2.2.13",
+        "pestphp/pest-plugin-rector": "5.0.4",
         "pestphp/pest-plugin-type-coverage": "^5.0",
         "pushery/wirekit": "^2.26",
         "rector/rector": "2.6.3",

--- a/config/email-magic-link.php
+++ b/config/email-magic-link.php
@@ -317,8 +317,9 @@ return [
     |   true    same, and warn at boot if Fortify is missing
     |   false   never activate, even when Fortify is installed
     |
-    | "respect_two_factor" governs whether a magic-link user with confirmed TOTP
-    | is routed through Fortify's challenge. Setting it false is a deliberate
+    | "respect_two_factor" governs whether a magic-link user with two-factor
+    | authentication enabled (by Fortify's own verdict) is routed through
+    | Fortify's challenge. Setting it false is a deliberate
     | security downgrade that disables 2FA for magic-link logins; it emits a
     | boot-time warning.
     |
@@ -354,8 +355,9 @@ return [
     | their sign-in. Its default is correspondingly higher: a page load is cheap and
     | a person may open the link more than once.
     |
-    | The three other GET routes carry no limiter at all: they are forms, they carry
-    | no credential, and they spend nothing.
+    | The other GET routes -- the two forms, the signed confirmation page and the
+    | static countdown script -- carry no limiter at all: none carries a credential,
+    | and none spends anything.
     |
     */
 
@@ -389,12 +391,33 @@ return [
     | atomic locks (the array, file, database, redis, and memcached stores all
     | do); leave "store" null to use the default cache store.
     |
+    | The state IS a cache entry: `cache:clear` resets every cooldown and every
+    | rolling window at once, and the array store holds it for one process only,
+    | so on that store the guard throttles nothing outside a test.
+    |
     | "enabled" turns off throttling on THIS package's request endpoint and
     | nothing else. Keys you own stay guarded — the switch is checked by the
     | endpoint, not by the guard, so disabling magic-link throttling can never
     | disarm your own flood protection.
     |
     */
+
+    'resend' => [
+        'enabled' => env('EMAIL_MAGIC_LINK_RESEND', true),
+
+        'cooldown' => [
+            'base' => 30,
+            'factor' => 2,
+            'max' => 900,
+        ],
+
+        'window' => [
+            'minutes' => 60,
+            'max_sends' => 5,
+        ],
+
+        'store' => null,
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -414,11 +437,20 @@ return [
     | "frequency" accepts: hourly, daily, weekly, monthly. Anything else falls
     | back to daily rather than failing a boot over a typo in a cleanup cadence.
     |
+    | "chunk" is how many rows one DELETE removes. The purge loops until nothing is
+    | left, so the total is the same; what changes is how long any one statement
+    | holds its row locks against the sign-ins happening at the same time.
+    |
+    | Under multi-tenancy the scheduled entry runs on the central connection with no
+    | tenant context. Leave "schedule" off there and run the command through your
+    | tenancy runner instead; see "Running under multi-tenancy" in the documentation.
+    |
     */
 
     'prune' => [
         'schedule' => false,
         'frequency' => 'daily',
+        'chunk' => 1000,
     ],
 
     /*
@@ -463,23 +495,6 @@ return [
         'view' => null,
         'redirect_to' => '/',
         'retain_accepted_days' => 30,
-    ],
-
-    'resend' => [
-        'enabled' => env('EMAIL_MAGIC_LINK_RESEND', true),
-
-        'cooldown' => [
-            'base' => 30,
-            'factor' => 2,
-            'max' => 900,
-        ],
-
-        'window' => [
-            'minutes' => 60,
-            'max_sends' => 5,
-        ],
-
-        'store' => null,
     ],
 
 ];

--- a/lang/de/messages.php
+++ b/lang/de/messages.php
@@ -55,5 +55,7 @@ return [
     'mail_code_expiry' => 'Dieser Code läuft in :minutes Minuten ab.',
 
     // Notification — shared.
+    'mail_greeting' => 'Hallo!',
+    'mail_salutation' => 'Viele Grüße, :app',
     'mail_ignore' => 'Falls du dies nicht angefordert hast, kannst du diese E-Mail ignorieren.',
 ];

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -55,5 +55,7 @@ return [
     'mail_code_expiry' => 'This code expires in :minutes minutes.',
 
     // Notification — shared.
+    'mail_greeting' => 'Hello!',
+    'mail_salutation' => 'Kind regards, :app',
     'mail_ignore' => 'If you did not request this, you can safely ignore this email.',
 ];

--- a/lang/en_GB/messages.php
+++ b/lang/en_GB/messages.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+// The ISO 15897 spelling of the locale, which is the form Laravel's documentation
+// prescribes for territory variants (`en_GB` rather than `en-GB`). The translator
+// matches the directory name literally, so both spellings have to exist for the
+// bundle to be found; this one delegates to the file that carries the strings.
+return require __DIR__.'/../en/messages.php';

--- a/lang/en_US/messages.php
+++ b/lang/en_US/messages.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+// The ISO 15897 spelling of the locale, which is the form Laravel's documentation
+// prescribes for territory variants (`en_US` rather than `en-US`). The translator
+// matches the directory name literally, so both spellings have to exist for the
+// bundle to be found; this one delegates to the file that carries the strings.
+return require __DIR__.'/../en/messages.php';

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -55,5 +55,7 @@ return [
     'mail_code_expiry' => 'Este código caduca en :minutes minutos.',
 
     // Notification — shared.
+    'mail_greeting' => '¡Hola!',
+    'mail_salutation' => 'Saludos, :app',
     'mail_ignore' => 'Si no has solicitado esto, puedes ignorar este correo de forma segura.',
 ];

--- a/lang/fr/messages.php
+++ b/lang/fr/messages.php
@@ -55,5 +55,7 @@ return [
     'mail_code_expiry' => 'Ce code expire dans :minutes minutes.',
 
     // Notification — shared.
+    'mail_greeting' => 'Bonjour !',
+    'mail_salutation' => 'Cordialement, :app',
     'mail_ignore' => 'Si vous n’êtes pas à l’origine de cette demande, vous pouvez ignorer cet e-mail en toute sécurité.',
 ];

--- a/lang/it/messages.php
+++ b/lang/it/messages.php
@@ -55,5 +55,7 @@ return [
     'mail_code_expiry' => 'Questo codice scade tra :minutes minuti.',
 
     // Notification — shared.
+    'mail_greeting' => 'Ciao!',
+    'mail_salutation' => 'Cordiali saluti, :app',
     'mail_ignore' => 'Se non hai richiesto questo, puoi ignorare questa email in sicurezza.',
 ];

--- a/lang/nl/messages.php
+++ b/lang/nl/messages.php
@@ -55,5 +55,7 @@ return [
     'mail_code_expiry' => 'Deze code verloopt over :minutes minuten.',
 
     // Notification — shared.
+    'mail_greeting' => 'Hallo!',
+    'mail_salutation' => 'Met vriendelijke groet, :app',
     'mail_ignore' => 'Als je dit niet hebt aangevraagd, kun je deze e-mail veilig negeren.',
 ];

--- a/lang/pt-PT/messages.php
+++ b/lang/pt-PT/messages.php
@@ -65,5 +65,7 @@ return [
     'mail_code_expiry' => 'Este código expira em :minutes minutos.',
 
     // Notification — shared.
+    'mail_greeting' => 'Olá!',
+    'mail_salutation' => 'Cumprimentos, :app',
     'mail_ignore' => 'Se não solicitaste isto, podes ignorar este e-mail em segurança.',
 ];

--- a/lang/pt/messages.php
+++ b/lang/pt/messages.php
@@ -55,5 +55,7 @@ return [
     'mail_code_expiry' => 'Este código expira em :minutes minutos.',
 
     // Notification — shared.
+    'mail_greeting' => 'Olá!',
+    'mail_salutation' => 'Atenciosamente, :app',
     'mail_ignore' => 'Se não solicitou isto, pode ignorar este e-mail em segurança.',
 ];

--- a/lang/pt_BR/messages.php
+++ b/lang/pt_BR/messages.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+// The ISO 15897 spelling of the locale, which is the form Laravel's documentation
+// prescribes for territory variants (`pt_BR` rather than `pt-BR`). The translator
+// matches the directory name literally, so both spellings have to exist for the
+// bundle to be found; this one delegates to the file that carries the strings.
+return require __DIR__.'/../pt/messages.php';

--- a/lang/pt_PT/messages.php
+++ b/lang/pt_PT/messages.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+// The ISO 15897 spelling of the locale, which is the form Laravel's documentation
+// prescribes for territory variants (`pt_PT` rather than `pt-PT`). The translator
+// matches the directory name literally, so both spellings have to exist for the
+// bundle to be found; this one delegates to the file that carries the strings.
+return require __DIR__.'/../pt-PT/messages.php';

--- a/resources/boost/skills/email-magic-link-for-laravel/SKILL.md
+++ b/resources/boost/skills/email-magic-link-for-laravel/SKILL.md
@@ -77,7 +77,9 @@ decide the shape of the integration:
 | `invalid_response.via` | What an expired or invalid link renders: `redirect`, `view`, `abort`, `json`, or your own `InvalidLinkResponder` class-string |
 | `fortify.mode` | `auto` (bridge on when Fortify is installed), plus `respect_two_factor` |
 | `prune.schedule` | Register the daily token purge in the scheduler. Off by default — see Housekeeping |
-| `ui.script_nonce` | A `ScriptNonce` class supplying the CSP nonce for the countdown script; `null` auto-detects `csp_nonce()` |
+| `ui.script_nonce` | A `ScriptNonce` class supplying the CSP nonce for every tag the bundled screens emit (countdown script, inline stylesheet, WireKit's tags); `null` reads the `csp-nonce` container binding spatie/laravel-csp registers, then a global `csp_nonce()` |
+| `invitations.enabled` | Turn on the invitation channel; needs `invitations.handler` and `invitations.view` — see Invitations |
+| `prune.chunk` | Rows one purge `DELETE` removes (default 1000) |
 
 ### 3. Apply the package
 
@@ -92,6 +94,7 @@ browser flow under the `web` middleware group:
 | `POST` | `/magic-link/verify/{token}` | `email-magic-link.consume` |
 | `GET` | `/magic-link/code` | `email-magic-link.code.form` |
 | `POST` | `/magic-link/code` | `email-magic-link.code.consume` |
+| `GET` | `/magic-link/resend-countdown.js` | `email-magic-link.resend-countdown-script` |
 
 ```blade
 <a href="{{ route('email-magic-link.request.form') }}">Sign in without a password</a>
@@ -196,12 +199,45 @@ deletes, custom columns) by binding the contract:
 
 The same pattern applies to `token_store`, `captcha` and `invalid_response.via`
 — each takes the class-string of a published contract under
-`EmailMagicLink\\Contracts` and falls back to a bundled default.
+`EmailMagicLink\Contracts` and falls back to a bundled default.
 
 `notification` is the odd one out and is **not** a contract: it takes a class that
 **extends `MagicLinkNotification`**. Anything else is ignored — the package falls
 back to the bundled notification without raising, so a wrong class-string looks
 like it worked.
+
+### Invitations — for somebody who has no account yet
+
+A magic link signs in a user who exists. To onboard an address that has no account, use
+the invitation channel, never the sign-in flow (which would sign a non-member in):
+
+```php
+// config/email-magic-link.php
+'invitations' => [
+    'enabled' => true,
+    'handler' => App\Auth\AcceptInvitation::class,   // implements InvitationHandler
+    'view' => 'auth.accept-invitation',               // your screen; the package ships none
+],
+```
+
+```php
+$invitation = app(EmailMagicLink\Contracts\InvitationIssuer::class)
+    ->invite('newcomer@example.com', context: ['roles' => ['editor']]);
+
+Mail::to('newcomer@example.com')->send(new YouAreInvited($invitation->url));
+```
+
+The handler's `accept()` runs inside the transaction that spends the token: create the
+account, set the password, return the user to sign them in (or `null` to accept without a
+session). Two routes register while it is on: `GET|POST /magic-link/invitation/{token}`.
+`revoke($email)` withdraws every open invitation for an address.
+
+### Multi-tenancy
+
+An application that swaps its cache per tenant discards Laravel's rate limiter and every
+named limiter with it. Call `app(EmailMagicLink\Support\RateLimits::class)->define()` after the
+swap, and put the tenancy middleware into `routes.middleware`; leave `prune.schedule` off
+and run `email-magic-link:purge` through the tenancy runner instead.
 
 ## Anti-Patterns
 

--- a/resources/views/code.blade.php
+++ b/resources/views/code.blade.php
@@ -17,17 +17,22 @@
         @endif
 
         <label for="email">{{ __('email-magic-link::messages.email_label') }}</label>
-        <input id="email" name="email" type="email" autocomplete="email" required value="{{ $email ?: old('email') }}">
+        <input id="email" name="email" type="email" autocomplete="email" required value="{{ $email ?: old('email') }}"
+            @error('email') aria-invalid="true" aria-describedby="email-error" @enderror>
 
-        <label for="code" style="margin-top:1rem">{{ __('email-magic-link::messages.code_label') }}</label>
-        <input id="code" name="code" type="text" inputmode="text" autocomplete="one-time-code" required autofocus>
+        <label for="code" class="eml-code-label">{{ __('email-magic-link::messages.code_label') }}</label>
+        @php($emlNumeric = ctype_digit((string) config('email-magic-link.code_alphabet', '')))
+        <input id="code" name="code" type="text" inputmode="{{ $emlNumeric ? 'numeric' : 'text' }}"
+            @unless ($emlNumeric) autocapitalize="characters" spellcheck="false" @endunless
+            autocomplete="one-time-code" required autofocus
+            @error('code') aria-invalid="true" aria-describedby="code-error" @enderror>
 
         @error('code')
-            <p class="error">{{ $message }}</p>
+            <p class="error" id="code-error">{{ $message }}</p>
         @enderror
 
         @error('email')
-            <p class="error">{{ $message }}</p>
+            <p class="error" id="email-error">{{ $message }}</p>
         @enderror
 
         <button type="submit">{{ __('email-magic-link::messages.sign_in') }}</button>

--- a/resources/views/confirm.blade.php
+++ b/resources/views/confirm.blade.php
@@ -7,7 +7,7 @@
     <p>{{ __('email-magic-link::messages.confirm_intro') }}</p>
 
     @error('email')
-        <p class="error">{{ $message }}</p>
+        <p class="error" id="email-error" role="alert">{{ $message }}</p>
     @enderror
 
     <form method="POST" action="{{ $action }}">

--- a/resources/views/invalid.blade.php
+++ b/resources/views/invalid.blade.php
@@ -6,5 +6,5 @@
     <h1>{{ __('email-magic-link::messages.invalid_title') }}</h1>
     <p>{{ $message }}</p>
 
-    <p><a href="{{ route('email-magic-link.request.form') }}">{{ __('email-magic-link::messages.sign_in') }}</a></p>
+    <p><a class="button" href="{{ route('email-magic-link.request.form') }}">{{ __('email-magic-link::messages.sign_in') }}</a></p>
 @endsection

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -1,10 +1,14 @@
+{{-- The language the page SPEAKS, not the one that was asked for: on a locale this package
+     has no bundle for (and the host published none), the strings fall back, and a `lang`
+     that still names the requested locale sends a screen reader to the wrong voice. --}}
+@php($emlLocale = app('translator')->has('email-magic-link::messages.sign_in', app()->getLocale(), false) ? app()->getLocale() : (string) config('app.fallback_locale', 'en'))
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<html lang="{{ str_replace('_', '-', $emlLocale) }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
-    <title>@yield('title', __('email-magic-link::messages.sign_in')) &middot; {{ config('app.name') }}</title>
+    <title>@yield('title', __('email-magic-link::messages.sign_in')) &raquo; {{ config('app.name') }}</title>
 
     {{-- The application's per-response CSP nonce, or null when it has no policy.
          The WireKit layout has noncing its inline <style> since the CSP work; this one
@@ -32,6 +36,7 @@
         body {
             margin: 0;
             min-height: 100vh;
+            min-height: 100dvh; /* iOS Safari: the visible viewport, not the toolbar-inclusive one */
             display: grid;
             place-items: center;
             font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
@@ -47,7 +52,7 @@
         h1 { font-size: 1.25rem; margin: 0 0 1rem; }
         p { line-height: 1.5; margin: 0 0 1rem; }
         label { display: block; font-weight: 600; margin: 0 0 0.25rem; }
-        input[type="email"], input[type="text"] {
+        input[type="email"], input[type="text"], input[type="password"] {
             width: 100%;
             padding: 0.6rem 0.75rem;
             font-size: 1rem;
@@ -57,7 +62,7 @@
             background: Field;
             color: FieldText;
         }
-        button {
+        button, a.button {
             width: 100%;
             margin-top: 1rem;
             padding: 0.65rem 1rem;
@@ -65,13 +70,27 @@
             font-weight: 600;
             border: 0;
             border-radius: 0.5rem;
-            background: AccentColor;
-            color: AccentColorText;
+            /* CanvasText on Canvas, not AccentColor: Chromium's default accent (#0075ff) puts
+               white text at 4.2:1, below the 4.5:1 AA floor, in both color schemes. */
+            background: CanvasText;
+            color: Canvas;
             cursor: pointer;
         }
         .status { padding: 0.75rem 1rem; border-radius: 0.5rem; background: color-mix(in srgb, AccentColor 15%, transparent); margin-bottom: 1rem; }
         .error { color: #b00020; margin: 0.4rem 0 0; font-size: 0.9rem; }
+        /* #b00020 is 2.55:1 on Chromium's dark Canvas (#121212); this pair is 8.1:1. */
+        @media (prefers-color-scheme: dark) { .error { color: #ff8a80; } }
+        button[aria-disabled="true"] { opacity: 0.6; cursor: default; }
         fieldset { border: 0; padding: 0; margin: 0 0 1rem; }
+        fieldset label { display: flex; align-items: center; gap: 0.5rem; margin: 0; }
+        a.button { display: inline-block; width: auto; text-decoration: none; box-sizing: border-box; }
+        /* A class, not a style attribute: `style-src-attr` is never satisfied by a nonce. */
+        .eml-code-label { margin-top: 1rem; }
+        /* Touch floors: 44 px targets and rows where a thumb lands, as the WireKit path has. */
+        @media (pointer: coarse) {
+            input:not([type="radio"]), button, a.button { min-height: 2.75rem; }
+            fieldset label { min-height: 2.75rem; }
+        }
     </style>
 </head>
 <body>

--- a/resources/views/partials/resend-countdown.blade.php
+++ b/resources/views/partials/resend-countdown.blade.php
@@ -29,6 +29,7 @@
          announcement. (WireKit's own countdown component reaches the same conclusion
          for the same reason.) --}}
     <p
+        id="eml-resend-countdown"
         class="eml-resend-countdown"
         role="timer"
         aria-label="{{ __('email-magic-link::messages.resend_countdown_label') }}"

--- a/resources/views/request.blade.php
+++ b/resources/views/request.blade.php
@@ -14,22 +14,27 @@
         @csrf
 
         <label for="email">{{ __('email-magic-link::messages.email_label') }}</label>
-        <input id="email" name="email" type="email" autocomplete="email" required autofocus value="{{ old('email') }}">
+        <input id="email" name="email" type="email" autocomplete="email" required autofocus value="{{ old('email') }}"
+            @error('email') aria-invalid="true" aria-describedby="email-error" @enderror>
 
-        @error('email')
-            <p class="error">{{ $message }}</p>
-        @enderror
+        {{-- Skipped while a resend is held back: the countdown below carries that message and
+             keeps it current; a second, static copy would say "30 seconds" for the whole wait. --}}
+        @if (! session('resend_retry_after'))
+            @error('email')
+                <p class="error" id="email-error">{{ $message }}</p>
+            @enderror
+        @endif
 
         @if ($mode === 'both')
             <fieldset>
                 <legend>{{ __('email-magic-link::messages.delivery_legend') }}</legend>
-                <label><input type="radio" name="channel" value="link" checked> {{ __('email-magic-link::messages.delivery_link') }}</label>
-                <label><input type="radio" name="channel" value="code"> {{ __('email-magic-link::messages.delivery_code') }}</label>
+                <label><input type="radio" name="channel" value="link" @checked(old('channel', 'link') === 'link')> {{ __('email-magic-link::messages.delivery_link') }}</label>
+                <label><input type="radio" name="channel" value="code" @checked(old('channel') === 'code')> {{ __('email-magic-link::messages.delivery_code') }}</label>
             </fieldset>
         @endif
 
-        <button type="submit">{{ $mode === 'code' ? __('email-magic-link::messages.request_send_code') : __('email-magic-link::messages.request_send_link') }}</button>
-    </form>
+        @include('email-magic-link::partials.resend-countdown')
 
-    @include('email-magic-link::partials.resend-countdown')
+        <button type="submit"{!! session('resend_retry_after') ? ' aria-describedby="eml-resend-countdown"' : '' !!}>{{ $mode === 'code' ? __('email-magic-link::messages.request_send_code') : __('email-magic-link::messages.request_send_link') }}</button>
+    </form>
 @endsection

--- a/resources/views/wirekit/code.blade.php
+++ b/resources/views/wirekit/code.blade.php
@@ -6,7 +6,7 @@
     <x-wirekit::card>
         <x-wirekit::card.body>
             <x-wirekit::stack>
-                <x-wirekit::heading>{{ __('email-magic-link::messages.code_heading') }}</x-wirekit::heading>
+                <x-wirekit::heading :level="1">{{ __('email-magic-link::messages.code_heading') }}</x-wirekit::heading>
                 <x-wirekit::text>{{ __('email-magic-link::messages.code_intro') }}</x-wirekit::text>
 
                 @if (session('status'))
@@ -50,8 +50,8 @@
                          channel never reaches this screen anyway — EntropyGuard refuses to
                          mint from defaults it was not given — so this is the belt for a
                          config that is present but blank. --}}
-                    @php($emlAlphabet = (string) config('email-magic-link.code_alphabet', ''))
-                    @php($emlCodeLength = (int) config('email-magic-link.code_length', 8))
+                    @php($emlAlphabet = app(\EmailMagicLink\Support\MagicLinkConfig::class)->codeAlphabet())
+                    @php($emlCodeLength = app(\EmailMagicLink\Support\MagicLinkConfig::class)->codeLength())
 
                     <x-wirekit::otp-input
                         name="code"

--- a/resources/views/wirekit/confirm.blade.php
+++ b/resources/views/wirekit/confirm.blade.php
@@ -6,7 +6,7 @@
     <x-wirekit::card>
         <x-wirekit::card.body>
             <x-wirekit::stack>
-                <x-wirekit::heading>{{ __('email-magic-link::messages.heading', ['app' => config('app.name')]) }}</x-wirekit::heading>
+                <x-wirekit::heading :level="1">{{ __('email-magic-link::messages.heading', ['app' => config('app.name')]) }}</x-wirekit::heading>
                 <x-wirekit::text>{{ __('email-magic-link::messages.confirm_intro') }}</x-wirekit::text>
 
                 @error('email')

--- a/resources/views/wirekit/layout.blade.php
+++ b/resources/views/wirekit/layout.blade.php
@@ -1,10 +1,14 @@
+{{-- The language the page SPEAKS, not the one that was asked for: on a locale this package
+     has no bundle for (and the host published none), the strings fall back, and a `lang`
+     that still names the requested locale sends a screen reader to the wrong voice. --}}
+@php($emlLocale = app('translator')->has('email-magic-link::messages.sign_in', app()->getLocale(), false) ? app()->getLocale() : (string) config('app.fallback_locale', 'en'))
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<html lang="{{ str_replace('_', '-', $emlLocale) }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
-    <title>@yield('title', __('email-magic-link::messages.sign_in')) &middot; {{ config('app.name') }}</title>
+    <title>@yield('title', __('email-magic-link::messages.sign_in')) &raquo; {{ config('app.name') }}</title>
 
     {{-- The application's per-response CSP nonce, or null when it has no policy.
          Resolved once here and handed to every tag on this page that a strict
@@ -29,10 +33,11 @@
          @source'd) supplies the component utility classes. ui.vite points at
          the host's Vite entrypoint; set it false for a non-Vite host. ui.styles
          <link>s plain pre-compiled stylesheets (a CDN bundle, an asset() path). --}}
-    @if ($emlVite = config('email-magic-link.ui.vite', ['resources/css/app.css']))
+    @php($emlConfig = app(\EmailMagicLink\Support\MagicLinkConfig::class))
+    @if ($emlVite = $emlConfig->uiVite())
         @vite($emlVite)
     @endif
-    @foreach ((array) config('email-magic-link.ui.styles', []) as $emlStylesheet)
+    @foreach ($emlConfig->uiStyles() as $emlStylesheet)
         <link rel="stylesheet" href="{{ $emlStylesheet }}">
     @endforeach
 
@@ -42,11 +47,14 @@
          shell in a tiny inline stylesheet centers the sign-in screen in any
          host, scanned or not. The card's own surface, spacing, and type still
          come from the WireKit tokens loaded above. --}}
+    {{-- No color-scheme here: WireKit declares `light` on :root and `dark` under .dark
+         (both at zero specificity, since 2.29.0), and an override to `light dark` painted
+         native widgets dark on a page whose tokens stayed light. --}}
     <style{!! $emlNonce === null ? '' : ' nonce="'.e($emlNonce).'"' !!}>
-        :root { color-scheme: light dark; }
         body {
             margin: 0;
             min-height: 100vh;
+            min-height: 100dvh;
             display: grid;
             place-items: center;
             background: var(--color-wk-bg, Canvas);
@@ -78,12 +86,10 @@
          is CSS, so a missed plugin registration is invisible to it.
 
          Nonced for the same reason as the stylesheet above. A host that cannot
-         grant 'unsafe-eval' has a lever since WireKit 2.22.0 —
-         `wirekit.scripts.bundle = 'csp'`, built against Alpine's CSP distribution
-         — but it is only half the answer here, and the docs say which half:
-         @wirekitScripts force-injects Livewire's assets so Alpine reaches a
-         pure-Blade page, and Livewire compiles its own directives at runtime the
-         same way Alpine's default build does.
+         grant 'unsafe-eval' needs Livewire's CSP build (`livewire.csp_safe`), not
+         WireKit's: Livewire's tag carries no `defer` and runs first, so its Alpine is
+         the one that starts; WireKit's `csp` bundle detects it, registers against it
+         and never starts an Alpine of its own. See "WireKit screens" in the docs.
 
          BOTH tags take the nonce, and the second one is easy to forget: WireKit
          emits its own <script>, and @livewireScripts emits Livewire's. Without an

--- a/resources/views/wirekit/request.blade.php
+++ b/resources/views/wirekit/request.blade.php
@@ -6,7 +6,7 @@
     <x-wirekit::card>
         <x-wirekit::card.body>
             <x-wirekit::stack>
-                <x-wirekit::heading>{{ __('email-magic-link::messages.heading', ['app' => config('app.name')]) }}</x-wirekit::heading>
+                <x-wirekit::heading :level="1">{{ __('email-magic-link::messages.heading', ['app' => config('app.name')]) }}</x-wirekit::heading>
                 <x-wirekit::text>{{ $mode === 'code' ? __('email-magic-link::messages.request_intro_code') : __('email-magic-link::messages.request_intro_link') }}</x-wirekit::text>
 
                 @if (session('status'))
@@ -24,7 +24,7 @@
                         required
                         autofocus
                         :value="old('email')"
-                        :error="$errors->first('email')"
+                        :error="session('resend_retry_after') ? null : $errors->first('email')"
                     />
 
                     @if ($mode === 'both')
@@ -35,17 +35,21 @@
                              fieldset + legend; this set had lost it. field.set brings its
                              own spacing, so it replaces the stack rather than wrapping it. --}}
                         <x-wirekit::field.set :legend="__('email-magic-link::messages.delivery_legend')">
-                            <x-wirekit::radio name="channel" value="link" :label="__('email-magic-link::messages.delivery_link')" checked />
-                            <x-wirekit::radio name="channel" value="code" :label="__('email-magic-link::messages.delivery_code')" />
+                            {{-- old('channel'): a failed submit keeps the choice, or a person who picked
+                                 the code, mistyped the address and corrected it receives a link. --}}
+                            <x-wirekit::radio name="channel" value="link" :label="__('email-magic-link::messages.delivery_link')" :checked="old('channel', 'link') === 'link'" />
+                            <x-wirekit::radio name="channel" value="code" :label="__('email-magic-link::messages.delivery_code')" :checked="old('channel') === 'code'" />
                         </x-wirekit::field.set>
                     @endif
 
-                    <x-wirekit::button type="submit">
+                    {{-- Inside the form and before the button, so a keyboard user meets the
+                         reason for the hold-back before the button that is held back. --}}
+                    @include('email-magic-link::partials.resend-countdown')
+
+                    <x-wirekit::button type="submit" :aria-describedby="session('resend_retry_after') ? 'eml-resend-countdown' : null">
                         {{ $mode === 'code' ? __('email-magic-link::messages.request_send_code') : __('email-magic-link::messages.request_send_link') }}
                     </x-wirekit::button>
                 </x-wirekit::stack>
-
-                @include('email-magic-link::partials.resend-countdown')
             </x-wirekit::stack>
         </x-wirekit::card.body>
     </x-wirekit::card>

--- a/src/Authenticators/FortifyAwareAuthenticator.php
+++ b/src/Authenticators/FortifyAwareAuthenticator.php
@@ -16,7 +16,8 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * The package's only Fortify-internal coupling.
  *
- * When the verified user has confirmed TOTP, the user is handed off to
+ * When the verified user has two-factor authentication enabled by Fortify's own
+ * verdict, the user is handed off to
  * Fortify's own challenge in a NOT-yet-authenticated state: the login.id /
  * login.remember session keys are set and the request is redirected to the
  * challenge route. The actual login happens inside Fortify, only after the code
@@ -24,7 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
  * guest middleware on the challenge route and bypass the second factor, so this
  * decorator must never do so.
  *
- * Users without confirmed two-factor fall through to the wrapped default
+ * Users without an enabled second factor fall through to the wrapped default
  * authenticator and are logged in directly.
  */
 final readonly class FortifyAwareAuthenticator implements MagicLinkAuthenticator
@@ -36,7 +37,7 @@ final readonly class FortifyAwareAuthenticator implements MagicLinkAuthenticator
 
     public function authenticate(Request $request, Authenticatable $user, string $guard, bool $remember): Response
     {
-        if (! $this->config->respectTwoFactor() || ! $this->hasConfirmedTwoFactor($user)) {
+        if (! $this->config->respectTwoFactor() || ! $this->hasEnabledTwoFactor($user)) {
             return $this->default->authenticate($request, $user, $guard, $remember);
         }
 
@@ -81,10 +82,19 @@ final readonly class FortifyAwareAuthenticator implements MagicLinkAuthenticator
         return $redirect;
     }
 
-    private function hasConfirmedTwoFactor(Authenticatable $user): bool
+    private function hasEnabledTwoFactor(Authenticatable $user): bool
     {
-        // Gate on confirmation, not mere secret presence, so a user mid-setup
-        // is not locked out of their own magic-link login.
+        // Fortify's own verdict, so the magic link challenges exactly the users the
+        // password login challenges. With `confirm` on, that is a secret AND a
+        // confirmed_at, which keeps a user mid-setup out of the challenge; with
+        // `confirm` off -- Fortify's shipped feature registration -- it is a secret
+        // alone, and confirmed_at is never written. Re-deriving the verdict from
+        // confirmed_at let an enabled second factor through on every host that had
+        // never turned confirmation on.
+        if (method_exists($user, 'hasEnabledTwoFactorAuthentication')) {
+            return (bool) $user->hasEnabledTwoFactorAuthentication();
+        }
+
         return data_get($user, 'two_factor_confirmed_at') !== null;
     }
 }

--- a/src/Console/Commands/DoctorCommand.php
+++ b/src/Console/Commands/DoctorCommand.php
@@ -9,6 +9,11 @@ use EmailMagicLink\Support\AutoScriptNonce;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Http\Kernel as KernelContract;
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+use Illuminate\Http\Middleware\TrustHosts;
+use Illuminate\Routing\UrlGenerator;
+use ReflectionProperty;
 
 /**
  * Reports what a published config file does not know about.
@@ -44,6 +49,7 @@ final class DoctorCommand extends Command
             // Also on this path: a host with no published config has the same CSP
             // question, and this branch returns before the report below.
             $this->reportScriptNonce($config);
+            $this->reportLinkOrigin($app);
 
             return self::SUCCESS;
         }
@@ -89,6 +95,7 @@ final class DoctorCommand extends Command
         }
 
         $this->reportScriptNonce($config);
+        $this->reportLinkOrigin($app);
 
         // Reporting, never gating: this runs in a deploy pipeline and a drifted
         // config is a thing to read, not a thing to fail a release on. `unknown`
@@ -111,13 +118,78 @@ final class DoctorCommand extends Command
      * warning with it. This command is already the place someone reads when they
      * have a question.
      *
-     * ⚠️ It reports the SOURCE, not the value, and that is a correctness point
+     * It reports the SOURCE, not the value, and that is a correctness point
      * rather than caution. The nonce is scoped per request; a console command either
      * cannot resolve the binding at all or resolves one that no response will ever
      * carry. Printing it would show a value that is real and useless. Whether the
      * SOURCE exists is the same question in the console as in a request, so that is
      * what gets answered.
      */
+    /**
+     * Report WHERE the host of an emailed link comes from.
+     *
+     * Laravel builds every URL from a forced origin when one is set and from the
+     * request's Host header otherwise. Behind a catch-all virtual host that means a
+     * forged Host lands in the victim's email with a valid token in the path. The
+     * three answers are "forced", "restricted by TrustHosts" and "the request as it
+     * came in" -- and only the third needs the operator's attention.
+     */
+    private function reportLinkOrigin(Application $app): void
+    {
+        $this->newLine();
+
+        if ($this->originIsForced($app)) {
+            $this->line('Link origin forced by the application (URL::useOrigin), so a request cannot choose it.');
+
+            return;
+        }
+
+        if ($this->trustsHosts($app)) {
+            $this->line('Link origin the request host, restricted by the TrustHosts middleware.');
+
+            return;
+        }
+
+        $this->line('Link origin the request\'s Host header, unrestricted.');
+        $this->line('            The host in every emailed link is whatever the request that asked');
+        $this->line('            for it carried. Restrict it with the TrustHosts middleware or force');
+        $this->line('            the origin from app.url. See "The host in the emailed link".');
+    }
+
+    private function originIsForced(Application $app): bool
+    {
+        // The container's generator, not the facade's root: the facade answers `mixed`
+        // and would need a guard branch no application can ever take.
+        $generator = $app->make(UrlGenerator::class);
+
+        // The generator has no getter for a forced origin; the property is the only witness.
+        $property = new ReflectionProperty(UrlGenerator::class, 'forcedRoot');
+
+        return $property->getValue($generator) !== null;
+    }
+
+    private function trustsHosts(Application $app): bool
+    {
+        $kernel = $app->make($this->kernelBinding());
+
+        // The contract does not expose the stack; the framework's kernel does, and every
+        // application kernel extends it.
+        return $kernel instanceof HttpKernel
+            && in_array(TrustHosts::class, $kernel->getGlobalMiddleware(), true);
+    }
+
+    /**
+     * The binding as a value rather than a literal: the analyser otherwise resolves it
+     * to the concrete kernel of whichever application it runs in and reads the
+     * instanceof above as settled.
+     *
+     * @return class-string<KernelContract>
+     */
+    private function kernelBinding(): string
+    {
+        return KernelContract::class;
+    }
+
     private function reportScriptNonce(Repository $config): void
     {
         $this->newLine();

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -56,9 +56,11 @@ final class InstallCommand extends Command
         $this->line('     does not know about yet:');
         $this->line('       php artisan email-magic-link:doctor');
         $this->newLine();
-        $this->line('The migration is loaded automatically; publish it with');
+        $this->line('The migrations are loaded automatically; publish them with');
         $this->line('  php artisan vendor:publish --tag=email-magic-link-migrations');
-        $this->line('only if you need to customize it.');
+        $this->line('only if you need to customize them. Once a published copy exists the bundled');
+        $this->line('files are no longer loaded, so nothing runs twice. If you rename the copy, call');
+        $this->line('EmailMagicLinkServiceProvider::ignoreMigrations() in a service provider.');
 
         return self::SUCCESS;
     }

--- a/src/Console/Commands/PurgeExpiredTokensCommand.php
+++ b/src/Console/Commands/PurgeExpiredTokensCommand.php
@@ -8,6 +8,7 @@ use EmailMagicLink\Contracts\InvitationStore;
 use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Support\MagicLinkConfig;
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Isolatable;
 
 /**
  * Deletes expired and consumed magic-link tokens — and, when invitations are
@@ -15,8 +16,12 @@ use Illuminate\Console\Command;
  *
  * Schedule it (for example daily) so neither table grows unbounded:
  * Schedule::command('email-magic-link:purge')->daily();
+ *
+ * Isolatable, so `--isolated` refuses a second copy while one runs -- the framework's
+ * own overlap guard, for a host that schedules the command itself. Deletes in chunks
+ * (config `prune.chunk`), so no single statement holds its row locks for long.
  */
-final class PurgeExpiredTokensCommand extends Command
+final class PurgeExpiredTokensCommand extends Command implements Isolatable
 {
     protected $signature = 'email-magic-link:purge';
 

--- a/src/Contracts/ScriptNonce.php
+++ b/src/Contracts/ScriptNonce.php
@@ -15,8 +15,10 @@ namespace EmailMagicLink\Contracts;
  * click too early. The apps most likely to run a strict CSP are exactly the ones
  * that care about the rest of this package.
  *
- * The default implementation detects the fleet-standard `csp_nonce()` helper, so
- * spatie/laravel-csp works with no configuration. Point `ui.script_nonce` at your
+ * The default implementation reads the `csp-nonce` container binding spatie/laravel-csp
+ * registers and falls back to a global `csp_nonce()` for hosts that define one, so
+ * spatie/laravel-csp works with no configuration; see `AutoScriptNonce`. Point
+ * `ui.script_nonce` at your
  * own implementation when the nonce lives somewhere else — a request attribute, a
  * middleware-set container binding, your own helper.
  *

--- a/src/EmailMagicLinkServiceProvider.php
+++ b/src/EmailMagicLinkServiceProvider.php
@@ -21,6 +21,7 @@ use EmailMagicLink\Contracts\ScriptNonce;
 use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Contracts\UserLookup;
 use EmailMagicLink\Exceptions\InvitationsMisconfiguredException;
+use EmailMagicLink\Http\Middleware\NoIndex;
 use EmailMagicLink\Http\Responses\DefaultInvalidLinkResponder;
 use EmailMagicLink\Lookups\DefaultUserLookup;
 use EmailMagicLink\Stores\DefaultInvitationStore;
@@ -41,6 +42,7 @@ use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Foundation\CachesConfiguration;
+use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
@@ -170,13 +172,26 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'email-magic-link');
         $this->loadTranslationsFrom(__DIR__.'/../lang', 'email-magic-link');
 
-        if (self::$runsMigrations) {
+        if (self::$runsMigrations && ! $this->migrationsArePublished()) {
             $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         }
 
         // Decided at boot so published config is in force (the authenticator is
         // only resolved at request time, after this wrapping is applied).
         $this->registerFortifyBridge($config);
+
+        // Registered before the master switch so `php artisan about` shows a
+        // disabled package as disabled instead of not at all.
+        AboutCommand::add('Email Magic Link', fn (): array => [
+            'Enabled' => $config->enabled() ? 'yes' : 'no',
+            'Mode' => $config->mode(),
+            'Fortify bridge' => match ($config->fortifyMode()) {
+                true => 'forced',
+                false => 'off',
+                default => 'auto',
+            },
+            'Invitations' => $config->invitationsEnabled() ? 'on' : 'off',
+        ]);
 
         if (! $config->enabled()) {
             return;
@@ -234,7 +249,9 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
                 default => $event->daily(),
             };
 
-            $event->withoutOverlapping();
+            $event->withoutOverlapping()
+                ->name('email-magic-link:purge')
+                ->description('Delete expired and consumed magic-link tokens, and settled invitations past their retention window.');
         });
     }
 
@@ -313,10 +330,28 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
         throw new InvalidArgumentException("[{$concrete}] must implement [{$contract}].");
     }
 
+    /**
+     * Whether the application already holds a published copy of the bundled migrations.
+     *
+     * publishesMigrations() gives each copy a fresh date prefix, so the copy and the
+     * bundled file are two migrations by name for one table, and `migrate` on a fresh
+     * database fails on the second CREATE with a message that names the table, not
+     * the cause. A host that publishes is expected to call ignoreMigrations(); this is
+     * the belt for the one that did not read that sentence. One readdir at boot.
+     */
+    private function migrationsArePublished(): bool
+    {
+        $copies = glob($this->app->databasePath('migrations/*_create_magic_link_tokens_table.php'));
+
+        return is_array($copies) && $copies !== [];
+    }
+
     private function registerRoutes(MagicLinkConfig $config): void
     {
         if (! $this->app->routesAreCached()) {
-            Route::middleware($config->routeMiddleware())
+            // NoIndex is appended here rather than listed in `routes.middleware`, so a
+            // host that overrides that key cannot drop it by accident.
+            Route::middleware([...$config->routeMiddleware(), NoIndex::class])
                 ->prefix($config->routePrefix())
                 ->group(__DIR__.'/../routes/email-magic-link.php');
         }
@@ -354,14 +389,18 @@ final class EmailMagicLinkServiceProvider extends ServiceProvider
                 __DIR__.'/../config/email-magic-link.php' => config_path('email-magic-link.php'),
             ], ['email-magic-link-config', 'email-magic-link']);
 
-            // publishesMigrations(), not publishes(): it rewrites the bundled
-            // 0001_01_01_00000N ordering prefix to the publish date. With a plain
-            // copy the published migrations keep that prefix and sort BEFORE the
-            // application's own create_users_table, so `migrate` on a fresh app
-            // tries to create a table with a foreign key to users that does not
-            // exist yet. The bundled prefix is correct for auto-loading (it must
-            // sort deterministically among the package's own) and wrong the
-            // moment the files land in the app's migrations directory.
+            // publishesMigrations(), not publishes(): when the framework's
+            // `database.migrations.update_date_on_publish` is on (its default), it
+            // rewrites the bundled 0001_01_01_00000N ordering prefix to the publish
+            // date. That prefix is right for auto-loading -- the four files only have
+            // to sort among themselves -- and wrong in the application's migrations
+            // directory, where it would sort them ahead of everything the host has and
+            // give every host the same file names. There is no foreign key at stake:
+            // user_id is a plain string column, on purpose.
+            //
+            // The rewrite has a cost, and boot() pays it: a copy with a fresh prefix is
+            // a DIFFERENT migration by name, so the bundled file and its copy would both
+            // be pending for one table. See migrationsArePublished().
             $this->publishesMigrations([
                 __DIR__.'/../database/migrations' => database_path('migrations'),
             ], ['email-magic-link-migrations', 'email-magic-link']);

--- a/src/Events/InvitationAccepted.php
+++ b/src/Events/InvitationAccepted.php
@@ -6,6 +6,7 @@ namespace EmailMagicLink\Events;
 
 use EmailMagicLink\Support\AcceptedInvitation;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Http\Request;
 
 /**
@@ -13,10 +14,13 @@ use Illuminate\Http\Request;
  *
  * Fired AFTER the transaction commits, so a listener can rely on the acceptance
  * having actually happened -- and so a slow listener cannot hold a database
- * transaction open. `$user` is whatever the handler returned: null means the
- * invitation was accepted without signing anybody in.
+ * transaction open. The dispatch site already sits outside the package's own
+ * transaction; ShouldDispatchAfterCommit makes the promise hold when the HOST
+ * wrapped the request in one (a transactional middleware, a test), which call
+ * order alone could not. `$user` is whatever the handler returned: null means
+ * the invitation was accepted without signing anybody in.
  */
-final readonly class InvitationAccepted
+final readonly class InvitationAccepted implements ShouldDispatchAfterCommit
 {
     public function __construct(
         public AcceptedInvitation $invitation,

--- a/src/Events/MagicLinkRequestRefused.php
+++ b/src/Events/MagicLinkRequestRefused.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Events;
+
+use EmailMagicLink\Support\RequestRefusal;
+use EmailMagicLink\Support\ResendDecision;
+use Illuminate\Http\Request;
+
+/**
+ * Fired when the request endpoint refuses to issue anything: the captcha failed,
+ * or the resend guard held the address back (cooldown or rolling cap).
+ *
+ * Observability only, and server-side only: the HTTP response stays generic and
+ * enumeration-resistant. The framework's own `throttle:` limiter answers 429
+ * before the controller runs and carries no event; a host that wants that one
+ * listens to RequestHandled with status 429.
+ *
+ * `email` is the normalized address the request carried, which may or may not
+ * belong to an account -- that is the point: a flood against unknown addresses
+ * is exactly the thing this event makes visible.
+ */
+final readonly class MagicLinkRequestRefused
+{
+    public function __construct(
+        public RequestRefusal $reason,
+        public string $email,
+        public ?ResendDecision $decision,
+        public Request $request,
+    ) {}
+}

--- a/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
+++ b/src/Http/Controllers/Concerns/CompletesMagicLinkLogin.php
@@ -10,6 +10,7 @@ use EmailMagicLink\Events\MagicLinkConsumptionFailed;
 use EmailMagicLink\Events\MagicLinkVerified;
 use EmailMagicLink\Models\MagicLinkToken;
 use EmailMagicLink\Support\ClaimFailure;
+use EmailMagicLink\Support\MagicLinkConfig;
 use EmailMagicLink\Support\ResendKey;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -29,6 +30,14 @@ trait CompletesMagicLinkLogin
 
     protected function completeLogin(Request $request, MagicLinkToken $token, string $failureRoute): Response
     {
+        // The guard was validated when the token was issued; re-checked here so an
+        // operator who removes a guard from the allowlist closes the door for links
+        // already in flight too. The row is spent either way, which is the fail-closed
+        // direction.
+        if (! in_array($token->guard, app(MagicLinkConfig::class)->allowedGuards(), true)) {
+            return $this->failedConsumption($request, $failureRoute, ClaimFailure::NotFound);
+        }
+
         $user = $this->resolveUser($token);
 
         if ($user === null) {
@@ -47,10 +56,8 @@ trait CompletesMagicLinkLogin
 
     protected function resolveUser(MagicLinkToken $token): ?Authenticatable
     {
-        $providerName = config("auth.guards.{$token->guard}.provider");
-
         return app(AuthManager::class)
-            ->createUserProvider(is_string($providerName) ? $providerName : null)
+            ->createUserProvider(app(MagicLinkConfig::class)->providerForGuard($token->guard))
             ?->retrieveById($token->user_id);
     }
 

--- a/src/Http/Controllers/ConsumeMagicLinkController.php
+++ b/src/Http/Controllers/ConsumeMagicLinkController.php
@@ -21,9 +21,13 @@ final class ConsumeMagicLinkController
 
     public function __invoke(Request $request, string $token, TokenStore $store): Response
     {
-        $passphrase = $request->string('passphrase')->toString();
+        // Read as raw input, not through string(): that helper casts, and an array
+        // value ("passphrase[]=a") was a 500 before the claim ran. Anything but a
+        // non-empty string is "no passphrase", which the claim then refuses.
+        $raw = $request->input('passphrase');
+        $passphrase = is_string($raw) && $raw !== '' ? $raw : null;
 
-        $result = $store->claimLink($token, $passphrase !== '' ? $passphrase : null);
+        $result = $store->claimLink($token, $passphrase);
         if (! $result->succeeded()) {
             return $this->failedConsumption($request, 'email-magic-link.request.form', $result->failure);
         }

--- a/src/Http/Controllers/SendMagicLinkController.php
+++ b/src/Http/Controllers/SendMagicLinkController.php
@@ -9,13 +9,16 @@ use EmailMagicLink\Contracts\ResendGuard;
 use EmailMagicLink\Contracts\TokenStore;
 use EmailMagicLink\Contracts\UserLookup;
 use EmailMagicLink\Events\MagicLinkRequested;
+use EmailMagicLink\Events\MagicLinkRequestRefused;
 use EmailMagicLink\Http\Controllers\Concerns\RespondsToApiClients;
 use EmailMagicLink\Http\Requests\SendMagicLinkRequest;
 use EmailMagicLink\Notifications\MagicLinkNotification;
 use EmailMagicLink\Support\ConfirmationUrl;
 use EmailMagicLink\Support\IssuedToken;
 use EmailMagicLink\Support\MagicLinkConfig;
+use EmailMagicLink\Support\RequestRefusal;
 use EmailMagicLink\Support\ResendDecision;
+use EmailMagicLink\Support\ResendDenialReason;
 use EmailMagicLink\Support\ResendKey;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Notification as NotificationSender;
@@ -78,8 +81,12 @@ final class SendMagicLinkController
         if ($user instanceof Authenticatable) {
             $issued = $store->issue($user, $guard, $channel);
 
+            // The notification is queued, and a worker renders it under ITS locale unless
+            // the request's travels with it. The mail route is an anonymous notifiable
+            // with no locale preference of its own, so this is the only place the
+            // request's language can be captured.
             NotificationSender::route('mail', $email)
-                ->notify($this->buildNotification($issued, $channel, $config));
+                ->notify($this->buildNotification($issued, $channel, $config)->locale(app()->getLocale()));
 
             event(new MagicLinkRequested($user, $channel, $request));
         }
@@ -92,6 +99,8 @@ final class SendMagicLinkController
 
     private function captchaFailed(SendMagicLinkRequest $request): Response
     {
+        event(new MagicLinkRequestRefused(RequestRefusal::Captcha, $request->email(), null, $request));
+
         $message = __('email-magic-link::messages.captcha_failed');
 
         if ($this->wantsJson($request)) {
@@ -105,6 +114,10 @@ final class SendMagicLinkController
 
     private function resendThrottled(SendMagicLinkRequest $request, ResendDecision $decision): Response
     {
+        if ($decision->reason instanceof ResendDenialReason) {
+            event(new MagicLinkRequestRefused(RequestRefusal::fromResendDenial($decision->reason), $request->email(), $decision, $request));
+        }
+
         $seconds = $decision->retryAfterSeconds;
         $message = __('email-magic-link::messages.resend_throttled', ['seconds' => $seconds]);
 
@@ -171,13 +184,12 @@ final class SendMagicLinkController
         }
 
         if ($channel === 'code') {
-            $params = ['email' => $email];
-
-            if ($guard !== null) {
-                $params['guard'] = $guard;
-            }
-
-            return redirect()->route('email-magic-link.code.form', $params)->with('status', $message);
+            // The address rides in the session, never in the URL: a query string
+            // lands in access logs, proxy logs, browser history and the Referer of
+            // every asset the code screen loads. Same handoff the retry path uses.
+            return redirect()->route('email-magic-link.code.form')
+                ->with('status', $message)
+                ->withInput(array_filter(['email' => $email, 'guard' => $guard], fn (?string $value): bool => $value !== null));
         }
 
         return redirect()->route('email-magic-link.request.form')->with('status', $message);

--- a/src/Http/Controllers/ShowCodeFormController.php
+++ b/src/Http/Controllers/ShowCodeFormController.php
@@ -21,8 +21,10 @@ final readonly class ShowCodeFormController
 
     public function __invoke(Request $request): View
     {
-        $email = $request->query('email');
-        $guard = $request->query('guard');
+        // Flashed by the request endpoint (and by a refused code) -- the address is
+        // never read from the query string, so it never has to be put there.
+        $email = $request->old('email');
+        $guard = $request->old('guard');
 
         return $this->views->make($this->config->view('code'), [
             'email' => is_string($email) ? $email : '',

--- a/src/Http/Controllers/ShowInvitationController.php
+++ b/src/Http/Controllers/ShowInvitationController.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
  * link-following scanner or a browser prefetch cannot burn the invitation before the
  * invited person ever sees it. Only the POST spends it.
  *
- * The order of the three steps is the ticket's fourth promise made structural. The
+ * The order of the three steps is a structural guarantee rather than a convention. The
  * refusal happens BEFORE the host's view is rendered, so a dead invitation can never
  * reach a screen that asks for a password -- and it is a promise rather than consumer
  * discipline only because this package owns the GET.

--- a/src/Http/Middleware/NoIndex.php
+++ b/src/Http/Middleware/NoIndex.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Keeps every response of the package's route group out of search indexes.
+ *
+ * The bundled layouts carry a robots meta tag, but four responses at these URLs never
+ * pass through them: the host's invitation acceptance view, a host-supplied invalid
+ * view, a custom InvalidLinkResponder, and the countdown script. The acceptance page
+ * is the one that shows the invited address at a URL carrying the token. A header
+ * covers what the body cannot, and a robots.txt cannot stand in: a disallowed URL is
+ * still indexed from an external reference, and the disallow hides the meta tag.
+ */
+final class NoIndex
+{
+    /**
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Robots-Tag', 'noindex, nofollow');
+
+        return $response;
+    }
+}

--- a/src/Http/Requests/ConsumeCodeRequest.php
+++ b/src/Http/Requests/ConsumeCodeRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EmailMagicLink\Http\Requests;
 
 use EmailMagicLink\Support\MagicLinkConfig;
+use EmailMagicLink\Support\NormalizedEmail;
 use Illuminate\Foundation\Http\FormRequest;
 use Override;
 
@@ -41,7 +42,7 @@ final class ConsumeCodeRequest extends FormRequest
         $code = $this->input('code');
 
         $this->merge([
-            'email' => is_string($email) ? mb_strtolower(trim($email)) : $email,
+            'email' => is_string($email) ? NormalizedEmail::from($email) : $email,
             'code' => is_string($code) ? $this->normalizeCode($code) : $code,
         ]);
     }

--- a/src/Http/Requests/SendMagicLinkRequest.php
+++ b/src/Http/Requests/SendMagicLinkRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Http\Requests;
 
+use EmailMagicLink\Support\NormalizedEmail;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 use Override;
@@ -41,7 +42,7 @@ final class SendMagicLinkRequest extends FormRequest
         $email = $this->input('email');
 
         if (is_string($email)) {
-            $this->merge(['email' => mb_strtolower(trim($email))]);
+            $this->merge(['email' => NormalizedEmail::from($email)]);
         }
     }
 

--- a/src/Http/Responses/DefaultInvalidLinkResponder.php
+++ b/src/Http/Responses/DefaultInvalidLinkResponder.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
  *             configured URL — with the generic error flashed and the email
  *             re-prefilled. Preserves the original browser behavior.
  *   view      render a Blade view (receives `message`), so the host owns the
- *             branding of the error page.
+ *             branding of the error page; answered with `abort_status`, never 200.
  *   abort     abort() with a configurable HTTP status, handing off to the
  *             application's own error page.
  *   json      return the JSON envelope ({message, error}) to every client, not
@@ -34,7 +34,10 @@ final readonly class DefaultInvalidLinkResponder implements InvalidLinkResponder
     public function respond(Request $request, string $message, string $failureRoute): Response
     {
         return match ($this->config->invalidResponseMode()) {
-            'view' => response()->view($this->config->invalidResponseView(), ['message' => $message]),
+            // The same status the abort strategy uses: a refusal rendered at 200 reads as a
+            // success to a link checker, a cache and a crawler, and the invitation GET is a
+            // URL that carries a token.
+            'view' => response()->view($this->config->invalidResponseView(), ['message' => $message], $this->config->invalidResponseAbortStatus()),
             'abort' => abort($this->config->invalidResponseAbortStatus(), $message),
             'json' => new JsonResponse(
                 ['message' => $message, 'error' => $this->config->invalidResponseErrorCode()],
@@ -52,11 +55,18 @@ final readonly class DefaultInvalidLinkResponder implements InvalidLinkResponder
             ? redirect()->to($target)
             : redirect()->route($failureRoute);
 
-        // Flash the email and guard (never the secret code) so the form can
-        // re-prefill on retry without putting them in the URL — keeping the
-        // response shape identical and enumeration-resistant.
+        // Flash only what the forms re-prefill -- the email and the guard -- so a
+        // retry keeps them without putting them in the URL. An allowlist, never a
+        // denylist: the consume form posts a passphrase and the host's acceptance
+        // form posts a password, and `except('code')` wrote both into the session
+        // store in the clear. The next secret field cannot land there either.
+        // The code form keys the generic failure on the CODE field: an unknown email and
+        // a wrong code still produce a byte-identical response (both come through here),
+        // but the field marked invalid is the one that was wrong.
+        $field = $failureRoute === 'email-magic-link.code.form' ? 'code' : 'email';
+
         return $redirect
-            ->withErrors(['email' => $message])
-            ->withInput($request->except('code'));
+            ->withErrors([$field => $message])
+            ->withInput($request->only(['email', 'guard']));
     }
 }

--- a/src/Lookups/DefaultUserLookup.php
+++ b/src/Lookups/DefaultUserLookup.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Config\Repository;
 /**
  * Resolves a user through the guard's configured user provider.
  *
- * Uses retrieveByCredentials so the lookup honours the application's provider
+ * Uses retrieveByCredentials so the lookup honors the application's provider
  * (Eloquent or database), model, and connection. A miss returns null with the
  * same single-query shape as a hit, keeping the request endpoint
  * enumeration-resistant.

--- a/src/Models/Invitation.php
+++ b/src/Models/Invitation.php
@@ -35,6 +35,11 @@ class Invitation extends Model
     /**
      * @var list<string>
      */
+    protected $hidden = ['token_hash'];
+
+    /**
+     * @var list<string>
+     */
     protected $fillable = [
         'email',
         'guard',

--- a/src/Models/MagicLinkToken.php
+++ b/src/Models/MagicLinkToken.php
@@ -33,6 +33,15 @@ class MagicLinkToken extends Model
     protected $table = 'magic_link_tokens';
 
     /**
+     * The passphrase hash is a bcrypt of a human-chosen secret, which is offline-crackable;
+     * the token hash is keyed. Neither belongs in a serialized model, and the model is
+     * exposed on public value objects.
+     *
+     * @var list<string>
+     */
+    protected $hidden = ['token_hash', 'passphrase_hash'];
+
+    /**
      * @var list<string>
      */
     protected $fillable = [

--- a/src/Notifications/MagicLinkNotification.php
+++ b/src/Notifications/MagicLinkNotification.php
@@ -52,19 +52,23 @@ class MagicLinkNotification extends Notification implements ShouldQueue
     {
         return (new MailMessage)
             ->subject(__('email-magic-link::messages.mail_link_subject', ['app' => $application]))
+            ->greeting(__('email-magic-link::messages.mail_greeting'))
             ->line(__('email-magic-link::messages.mail_link_intro', ['app' => $application]))
             ->action(__('email-magic-link::messages.mail_link_action'), (string) $this->actionUrl)
             ->line(__('email-magic-link::messages.mail_link_expiry', ['minutes' => $this->expiresInMinutes]))
-            ->line(__('email-magic-link::messages.mail_ignore'));
+            ->line(__('email-magic-link::messages.mail_ignore'))
+            ->salutation(__('email-magic-link::messages.mail_salutation', ['app' => $application]));
     }
 
     private function codeMessage(string $application): MailMessage
     {
         return (new MailMessage)
             ->subject(__('email-magic-link::messages.mail_code_subject', ['app' => $application]))
+            ->greeting(__('email-magic-link::messages.mail_greeting'))
             ->line(__('email-magic-link::messages.mail_code_intro', ['app' => $application]))
             ->line((string) $this->code)
             ->line(__('email-magic-link::messages.mail_code_expiry', ['minutes' => $this->expiresInMinutes]))
-            ->line(__('email-magic-link::messages.mail_ignore'));
+            ->line(__('email-magic-link::messages.mail_ignore'))
+            ->salutation(__('email-magic-link::messages.mail_salutation', ['app' => $application]));
     }
 }

--- a/src/Stores/DefaultInvitationStore.php
+++ b/src/Stores/DefaultInvitationStore.php
@@ -11,6 +11,7 @@ use EmailMagicLink\Support\ClaimFailure;
 use EmailMagicLink\Support\InvitationClaimResult;
 use EmailMagicLink\Support\IssuedInvitationToken;
 use EmailMagicLink\Support\MagicLinkConfig;
+use EmailMagicLink\Support\NormalizedEmail;
 use EmailMagicLink\Support\TokenHasher;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Database\Connection;
@@ -52,8 +53,8 @@ final readonly class DefaultInvitationStore implements InvitationStore
             //
             // Revoking first and inserting after is the obvious order and the wrong one --
             // two concurrent invites would each revoke what they saw and then both insert,
-            // leaving two live links for one address. That is the failure the ticket calls
-            // out by name.
+            // leaving two live links for one address -- the race this ordering exists to
+            // prevent.
             //
             // Already ACCEPTED rows are left alone: they are a record of something that
             // happened, not an open door.
@@ -74,7 +75,11 @@ final readonly class DefaultInvitationStore implements InvitationStore
         $now = Carbon::now();
         $hash = $this->hasher->hash($token);
 
+        // Pinned to the write connection, like every other read of a row the previous
+        // request may just have written: on a lagging replica the acceptance page
+        // otherwise refuses a fresh, valid invitation.
         $live = Invitation::query()
+            ->useWritePdo()
             ->where('token_hash', $hash)
             ->whereNull('accepted_at')
             ->whereNull('revoked_at')
@@ -119,25 +124,34 @@ final readonly class DefaultInvitationStore implements InvitationStore
         $now = Carbon::now();
         $retainUntil = $now->copy()->subDays($this->config->invitationRetainAcceptedDays());
 
-        $deleted = Invitation::query()
-            ->where(function (Builder $query) use ($now): void {
-                // Never accepted and past its lifetime: nothing to learn from it.
-                $query->where('expires_at', '<=', $now)
-                    ->whereNull('accepted_at')
-                    ->whereNull('revoked_at');
-            })
-            ->orWhere(function (Builder $query) use ($retainUntil): void {
-                // Settled rows carry the invited address in the clear, so they are kept
-                // only as long as the configured retention window -- an audit decision,
-                // which is why it is a config key rather than a constant.
-                $query->whereNotNull('accepted_at')->where('accepted_at', '<=', $retainUntil);
-            })
-            ->orWhere(function (Builder $query) use ($retainUntil): void {
-                $query->whereNotNull('revoked_at')->where('revoked_at', '<=', $retainUntil);
-            })
-            ->delete();
+        $chunk = $this->config->pruneChunk();
+        $deleted = 0;
 
-        return is_int($deleted) ? $deleted : 0;
+        // Chunked for the same reason as the sign-in store's purge: bounded lock time.
+        do {
+            $removed = Invitation::query()
+                ->where(function (Builder $query) use ($now): void {
+                    // Never accepted and past its lifetime: nothing to learn from it.
+                    $query->where('expires_at', '<=', $now)
+                        ->whereNull('accepted_at')
+                        ->whereNull('revoked_at');
+                })
+                ->orWhere(function (Builder $query) use ($retainUntil): void {
+                    // Settled rows carry the invited address in the clear, so they are kept
+                    // only as long as the configured retention window -- an audit decision,
+                    // which is why it is a config key rather than a constant.
+                    $query->whereNotNull('accepted_at')->where('accepted_at', '<=', $retainUntil);
+                })
+                ->orWhere(function (Builder $query) use ($retainUntil): void {
+                    $query->whereNotNull('revoked_at')->where('revoked_at', '<=', $retainUntil);
+                })
+                ->limit($chunk)
+                ->delete();
+            $removed = is_int($removed) ? $removed : 0;
+            $deleted += $removed;
+        } while ($removed === $chunk);
+
+        return $deleted;
     }
 
     /**
@@ -153,7 +167,10 @@ final readonly class DefaultInvitationStore implements InvitationStore
     {
         $connection = $this->connection();
 
-        $sql = 'update email_magic_link_invitations set accepted_at = ?, updated_at = ? '
+        // Same reason as the sign-in store: the prefix lives on the connection, not in a literal.
+        $table = $connection->getQueryGrammar()->wrapTable((new Invitation)->getTable());
+
+        $sql = "update {$table} set accepted_at = ?, updated_at = ? "
             .'where token_hash = ? and accepted_at is null and revoked_at is null and expires_at > ?';
         $bindings = [$now, $now, $hash, $now];
 
@@ -193,18 +210,22 @@ final readonly class DefaultInvitationStore implements InvitationStore
 
     /**
      * Why a claim or a peek found nothing. Reuses the sign-in failure enum: an
-     * invitation fails for the same three reasons a link does.
+     * invitation fails for the same three reasons a link does, plus revocation.
      */
     private function classify(string $hash, CarbonInterface $now): ClaimFailure
     {
-        $record = Invitation::query()->where('token_hash', $hash)->first();
+        $record = Invitation::query()->useWritePdo()->where('token_hash', $hash)->first();
 
         if (! $record instanceof Invitation) {
             return ClaimFailure::NotFound;
         }
 
-        if ($record->isAccepted() || $record->isRevoked()) {
+        if ($record->isAccepted()) {
             return ClaimFailure::AlreadyConsumed;
+        }
+
+        if ($record->isRevoked()) {
+            return ClaimFailure::Revoked;
         }
 
         return $record->isExpired($now) ? ClaimFailure::Expired : ClaimFailure::NotFound;
@@ -216,7 +237,7 @@ final readonly class DefaultInvitationStore implements InvitationStore
      */
     private function normalize(string $email): string
     {
-        return mb_strtolower(trim($email));
+        return NormalizedEmail::from($email);
     }
 
     /**

--- a/src/Stores/DefaultTokenStore.php
+++ b/src/Stores/DefaultTokenStore.php
@@ -100,7 +100,14 @@ final readonly class DefaultTokenStore implements TokenStore
             // response indistinguishable from an unknown or expired token.
             $existing = $this->findLinkByHash($hash);
 
-            if ($existing?->passphrase_hash !== null && ! $this->passphraseMatches($passphrase, $existing->passphrase_hash)) {
+            // Nothing to claim. The atomic UPDATE below could only miss, and the
+            // classifier would answer NotFound after a third SELECT -- so the path
+            // every scanner takes costs one statement, not three.
+            if (! $existing instanceof MagicLinkToken) {
+                return ClaimResult::failed(ClaimFailure::NotFound);
+            }
+
+            if ($existing->passphrase_hash !== null && ! $this->passphraseMatches($passphrase, $existing->passphrase_hash)) {
                 return ClaimResult::failed(ClaimFailure::InvalidPassphrase);
             }
 
@@ -172,14 +179,27 @@ final readonly class DefaultTokenStore implements TokenStore
 
     public function purge(): int
     {
-        $deleted = MagicLinkToken::query()
-            ->where(function (Builder $query): void {
-                $query->where('expires_at', '<=', Carbon::now())
-                    ->orWhereNotNull('consumed_at');
-            })
-            ->delete();
+        // In chunks, the way the framework's own pruning idiom works: one unbounded
+        // DELETE over months of rows holds every row lock until commit and stalls the
+        // claims running beside it. The predicate is re-evaluated per chunk, so a row
+        // that expires while the purge runs is picked up by the next one.
+        $chunk = $this->config->pruneChunk();
+        $now = Carbon::now();
+        $deleted = 0;
 
-        return is_int($deleted) ? $deleted : 0;
+        do {
+            $removed = MagicLinkToken::query()
+                ->where(function (Builder $query) use ($now): void {
+                    $query->where('expires_at', '<=', $now)
+                        ->orWhereNotNull('consumed_at');
+                })
+                ->limit($chunk)
+                ->delete();
+            $removed = is_int($removed) ? $removed : 0;
+            $deleted += $removed;
+        } while ($removed === $chunk);
+
+        return $deleted;
     }
 
     private function recordFailedCodeAttempt(MagicLinkToken $token, int $max, CarbonInterface $now): ClaimResult
@@ -230,7 +250,12 @@ final readonly class DefaultTokenStore implements TokenStore
     {
         $connection = $this->connection();
 
-        $sql = 'update magic_link_tokens set '
+        // wrapTable() applies the connection's table prefix and the driver's quoting. A
+        // literal table name here bypasses the prefix that Eloquent and Schema both honor,
+        // so on a prefixed connection every claim ran against a table that does not exist.
+        $table = $connection->getQueryGrammar()->wrapTable((new MagicLinkToken)->getTable());
+
+        $sql = "update {$table} set "
             .'consumed_at = case when uses_remaining <= 1 then ? else consumed_at end, '
             .'uses_remaining = uses_remaining - 1, updated_at = ? '
             ."where {$column} = ? and channel = ? and consumed_at is null and expires_at > ? and uses_remaining > 0";
@@ -250,7 +275,13 @@ final readonly class DefaultTokenStore implements TokenStore
 
     private function findLinkByHash(string $hash): ?MagicLinkToken
     {
+        // Pinned to the write connection: the confirm page asks whether a link wants a
+        // passphrase in a request of its own, after the one that issued the row, and on a
+        // lagging replica the answer was "no" for a link that does. The claim callers hold
+        // a transaction and would reach the write PDO anyway; stating it here keeps the
+        // property on the lookup rather than on whoever calls it.
         return MagicLinkToken::query()
+            ->useWritePdo()
             ->where('token_hash', $hash)
             ->where('channel', 'link')
             ->first();

--- a/src/Support/AutoScriptNonce.php
+++ b/src/Support/AutoScriptNonce.php
@@ -19,8 +19,8 @@ use Throwable;
  * 2. A global `csp_nonce()` function, kept for hosts that define one themselves.
  *
  * The order is not arbitrary, and the second probe used to be the ONLY one. That was
- * wrong for every current consumer: `csp_nonce()` arrived in spatie/laravel-csp 2.10.3
- * and exists nowhere in 3.x — measured against the package's own metadata, where every
+ * wrong for every current consumer: `csp_nonce()` existed in spatie/laravel-csp from
+ * 1.2.0 through 2.10.3, the last 2.x release, and exists nowhere in 3.x — measured against the package's own metadata, where every
  * 3.x release publishes `autoload.psr-4` and no `autoload.files`, so it cannot register
  * a global function at all. `function_exists('csp_nonce')` was therefore false for every
  * v3 host, this class returned null, and the countdown script shipped with no nonce

--- a/src/Support/ClaimFailure.php
+++ b/src/Support/ClaimFailure.php
@@ -18,4 +18,13 @@ enum ClaimFailure
     case InvalidCode;
     case InvalidPassphrase;
     case LockedOut;
+
+    /**
+     * An invitation that was withdrawn before anybody used it -- through revoke(), or
+     * by a newer invitation for the same address and guard superseding it.
+     * Distinct from AlreadyConsumed on purpose: a click on a revoked link is the
+     * one refusal that is a signal rather than noise, and a host that alerts on
+     * it must be able to tell it from a re-click on an accepted one.
+     */
+    case Revoked;
 }

--- a/src/Support/ClaimResult.php
+++ b/src/Support/ClaimResult.php
@@ -33,8 +33,8 @@ final readonly class ClaimResult
      * The constructor is private and there are exactly two ways in, so `successful` and
      * `token` are two views of one fact: success always carries a token, failure never
      * does and always carries a reason. Callers could not express that, and so wrote it
-     * out again as a second check on every branch -- a condition no input can reach, which
-     * is exactly the shape that leaves a mutant alive with no test able to kill it.
+     * out again as a second check on every branch -- a condition no input can reach and
+     * no test can exercise.
      *
      * @phpstan-assert-if-true !null $this->token
      *

--- a/src/Support/ConfirmationUrl.php
+++ b/src/Support/ConfirmationUrl.php
@@ -9,7 +9,7 @@ use EmailMagicLink\Models\MagicLinkToken;
 /**
  * Builds the signed, single-use confirmation URL for an issued link token.
  *
- * Centralised so the bundled email flow and the Mint-API emit the byte-for-byte
+ * Centralized so the bundled email flow and the Mint-API emit the byte-for-byte
  * same signed GET URL: the inert confirmation page. Only the POST consume route
  * mutates state, so this URL is safe for link-following scanners and prefetch.
  *

--- a/src/Support/DefaultResendGuard.php
+++ b/src/Support/DefaultResendGuard.php
@@ -7,6 +7,7 @@ namespace EmailMagicLink\Support;
 use EmailMagicLink\Contracts\ResendGuard;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Cache\LockProvider;
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Carbon;
 use RuntimeException;
@@ -57,10 +58,17 @@ final readonly class DefaultResendGuard implements ResendGuard
 
         $decision = ResendDecision::allowed();
 
-        $store->lock(self::LOCK_PREFIX.$this->digest($key), self::LOCK_SECONDS)
-            ->block(self::LOCK_SECONDS, function () use ($key, &$decision): void {
-                $decision = $this->evaluate($key, true);
-            });
+        try {
+            $store->lock(self::LOCK_PREFIX.$this->digest($key), self::LOCK_SECONDS)
+                ->block(self::LOCK_SECONDS, function () use ($key, &$decision): void {
+                    $decision = $this->evaluate($key, true);
+                });
+        } catch (LockTimeoutException) {
+            // A store that cannot hand out the lock in time is a store that cannot say
+            // whether the cap is reached. Fail closed with a short hold-back rather than
+            // let the exception become a 500 on the request endpoint.
+            return ResendDecision::denied(ResendDenialReason::Cooldown, self::LOCK_SECONDS);
+        }
 
         return $decision;
     }

--- a/src/Support/MagicLinkConfig.php
+++ b/src/Support/MagicLinkConfig.php
@@ -53,13 +53,11 @@ final readonly class MagicLinkConfig
      */
     public function ttlFor(string $channel): int
     {
-        $override = $this->config->get("email-magic-link.{$channel}_ttl");
+        // The same rule every other integer key follows: an int or a numeric string,
+        // nothing else. A float override used to be truncated here and rejected on `ttl`.
+        $override = $this->int($this->config->get("email-magic-link.{$channel}_ttl"), 0);
 
-        if (is_numeric($override) && (int) $override > 0) {
-            return (int) $override;
-        }
-
-        return $this->ttl();
+        return $override > 0 ? $override : $this->ttl();
     }
 
     /**
@@ -315,7 +313,7 @@ final readonly class MagicLinkConfig
      *
      * Mapped through a fixed set rather than passed to the scheduler as a method
      * name: a config value that reaches ->{$method}() is a config value that can
-     * call anything on the Schedule object. An unrecognised cadence falls back to
+     * call anything on the Schedule object. An unrecognized cadence falls back to
      * daily — a typo in a cleanup interval must not take down a boot.
      *
      * @return 'hourly'|'daily'|'weekly'|'monthly'
@@ -386,9 +384,26 @@ final readonly class MagicLinkConfig
         return is_string($to) && $to !== '' ? $to : null;
     }
 
+    /**
+     * Rows deleted per statement by the purge. One unbounded DELETE holds a row lock
+     * on everything it removes until commit; on a table that grew for months that is
+     * minutes of contention with the claims that are running at the same time.
+     */
+    public function pruneChunk(): int
+    {
+        $chunk = $this->int($this->config->get('email-magic-link.prune.chunk'), 1000);
+
+        return $chunk > 0 ? $chunk : 1000;
+    }
+
     public function invalidResponseAbortStatus(): int
     {
-        return $this->int($this->config->get('email-magic-link.invalid_response.abort_status'), 403);
+        $status = $this->int($this->config->get('email-magic-link.invalid_response.abort_status'), 403);
+
+        // A refusal answers with an error status or not at all: 200 would make the
+        // error page a success, and 0 or 999 is a 500 the moment Symfony renders it.
+        // Same shape as pruneFrequency(): a typo must not take down a sign-in.
+        return $status >= 400 && $status <= 599 ? $status : 403;
     }
 
     /**
@@ -406,6 +421,42 @@ final readonly class MagicLinkConfig
     /**
      * @return 'auto'|'blade'
      */
+    /**
+     * The host's Vite entrypoints for the WireKit layout, or false for a non-Vite host.
+     *
+     * @return list<string>|false
+     */
+    public function uiVite(): array|false
+    {
+        $vite = $this->config->get('email-magic-link.ui.vite', ['resources/css/app.css']);
+
+        if (in_array($vite, [false, null, []], true)) {
+            return false;
+        }
+
+        if (is_string($vite)) {
+            return $vite === '' ? false : [$vite];
+        }
+
+        return is_array($vite) ? array_values(array_filter($vite, is_string(...))) ?: false : false;
+    }
+
+    /**
+     * Pre-compiled stylesheets the WireKit layout links, in order.
+     *
+     * @return list<string>
+     */
+    public function uiStyles(): array
+    {
+        $styles = $this->config->get('email-magic-link.ui.styles', []);
+
+        if (is_string($styles)) {
+            return $styles === '' ? [] : [$styles];
+        }
+
+        return is_array($styles) ? array_values(array_filter($styles, is_string(...))) : [];
+    }
+
     public function uiMode(): string
     {
         return $this->string($this->config->get('email-magic-link.ui.mode'), 'auto') === 'blade'
@@ -455,11 +506,16 @@ final readonly class MagicLinkConfig
             return $mode;
         }
 
-        return match ($mode) {
-            'false' => false,
-            'true' => true,
-            default => 'auto',
-        };
+        if (! is_string($mode) || $mode === 'auto') {
+            return 'auto';
+        }
+
+        // Every spelling the other switches accept -- "0", "off", "no" and their
+        // opposites -- decides here too; EMAIL_MAGIC_LINK_FORTIFY=0 used to fall back
+        // to auto, the one value it was written to leave.
+        $decided = filter_var($mode, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        return is_bool($decided) ? $decided : 'auto';
     }
 
     public function respectTwoFactor(): bool

--- a/src/Support/NormalizedEmail.php
+++ b/src/Support/NormalizedEmail.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+use Illuminate\Support\Str;
+
+/**
+ * The one spelling of an address every lookup, limiter key and cache key agrees on.
+ *
+ * Str::trim() rather than trim(): it also strips the invisible characters a paste
+ * carries (NBSP, zero-width space, BOM), which PHP's trim() leaves in place. Under
+ * the framework's default middleware stack the input already arrived trimmed that
+ * way, so the two spellings only diverged for a host that removed TrimStrings --
+ * and then quietly, into a key that matched nothing.
+ */
+final class NormalizedEmail
+{
+    public static function from(string $email): string
+    {
+        return Str::lower(Str::trim($email));
+    }
+}

--- a/src/Support/RateLimits.php
+++ b/src/Support/RateLimits.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace EmailMagicLink\Support;
 
+use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\RateLimiter;
 
 /**
  * Builds the named rate limiters for the package's throttled endpoints.
@@ -22,7 +23,10 @@ use Illuminate\Support\Facades\RateLimiter;
  */
 final readonly class RateLimits
 {
-    public function __construct(private MagicLinkConfig $config) {}
+    public function __construct(
+        private MagicLinkConfig $config,
+        private Container $app,
+    ) {}
 
     /**
      * Register every limiter this package names, and do it again on demand.
@@ -37,12 +41,22 @@ final readonly class RateLimits
      * It is also the reason the pairing lives here rather than in the service
      * provider: a consumer copying three RateLimiter::for() lines by hand silently
      * loses a fourth limiter added later, and finds out as a 500 in production.
+     *
+     * The limiter is resolved from the CONTAINER at call time, never through the
+     * facade. The facade caches the first instance it resolved, so after the
+     * `forgetInstance()` above it would register these limiters on the discarded
+     * object -- while the throttle middleware, container-constructed, receives the
+     * new and empty one, and every throttled route answers 500. Measured: the
+     * repair the docblock describes only worked when the host ALSO cleared the
+     * facade, which nothing told it to do.
      */
     public function define(): void
     {
-        RateLimiter::for($this->config->requestLimiter(), fn (Request $http): array => $this->forRequest($http));
-        RateLimiter::for($this->config->consumeLimiter(), fn (Request $http): array => $this->forConsume($http));
-        RateLimiter::for($this->config->invitationViewLimiter(), fn (Request $http): array => $this->forInvitationView($http));
+        $limiter = $this->app->make(RateLimiter::class);
+
+        $limiter->for($this->config->requestLimiter(), fn (Request $http): array => $this->forRequest($http));
+        $limiter->for($this->config->consumeLimiter(), fn (Request $http): array => $this->forConsume($http));
+        $limiter->for($this->config->invitationViewLimiter(), fn (Request $http): array => $this->forInvitationView($http));
     }
 
     /**
@@ -52,7 +66,7 @@ final readonly class RateLimits
     {
         $limit = $this->config->requestLimit();
         $email = $request->input('email');
-        $email = is_string($email) ? mb_strtolower(trim($email)) : '';
+        $email = is_string($email) ? NormalizedEmail::from($email) : '';
 
         return [
             Limit::perMinutes($limit['per_minutes'], $limit['max'])->by('eml:req:email:'.$email),
@@ -103,6 +117,6 @@ final readonly class RateLimits
 
         $email = $request->input('email');
 
-        return is_string($email) ? mb_strtolower(trim($email)) : '';
+        return is_string($email) ? NormalizedEmail::from($email) : '';
     }
 }

--- a/src/Support/RequestRefusal.php
+++ b/src/Support/RequestRefusal.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmailMagicLink\Support;
+
+/**
+ * Why a sign-in REQUEST was refused before anything was issued.
+ *
+ * The consume side reports its failures through ClaimFailure; the request side
+ * had no counterpart, so a captcha failure or a held-back resend produced a
+ * response and no signal a host could alert on.
+ */
+enum RequestRefusal: string
+{
+    case Captcha = 'captcha';
+    case ResendCooldown = 'resend_cooldown';
+    case ResendWindowCap = 'resend_window_cap';
+
+    public static function fromResendDenial(ResendDenialReason $reason): self
+    {
+        return match ($reason) {
+            ResendDenialReason::Cooldown => self::ResendCooldown,
+            ResendDenialReason::WindowCap => self::ResendWindowCap,
+        };
+    }
+}

--- a/src/Support/ResendCountdownScript.php
+++ b/src/Support/ResendCountdownScript.php
@@ -46,14 +46,21 @@ final class ResendCountdownScript
             var template = el.getAttribute('data-template') || '';
             var remaining = parseInt(el.getAttribute('data-seconds'), 10) || 0;
 
+            // aria-disabled, not disabled: the button stays in the tab order and announces
+            // as dimmed, and aria-describedby on it names the countdown as the reason.
+            var block = function (e) { e.preventDefault(); };
+
             if (button) {
-                button.disabled = true;
+                button.setAttribute('aria-disabled', 'true');
+                form.addEventListener('submit', block);
             }
 
             (function tick() {
                 if (remaining <= 0) {
                     if (button) {
-                        button.disabled = false;
+                        button.removeAttribute('aria-disabled');
+                        button.removeAttribute('aria-describedby');
+                        form.removeEventListener('submit', block);
                     }
 
                     el.textContent = '';
@@ -82,7 +89,7 @@ final class ResendCountdownScript
      * holding the old one. Not a security boundary -- a cache key -- which is why a
      * truncated digest is enough.
      *
-     * Memoised because the input is a compile-time constant: the answer cannot change
+     * Memoized because the input is a compile-time constant: the answer cannot change
      * within a process, and this is called from a view.
      */
     public static function version(): string

--- a/src/Support/ResendKey.php
+++ b/src/Support/ResendKey.php
@@ -18,6 +18,6 @@ final class ResendKey
 
     public static function forRequest(string $email): string
     {
-        return self::REQUEST_PREFIX.mb_strtolower(trim($email));
+        return self::REQUEST_PREFIX.NormalizedEmail::from($email);
     }
 }

--- a/src/Support/SignedTokenUrl.php
+++ b/src/Support/SignedTokenUrl.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EmailMagicLink\Support;
 
 use Carbon\CarbonInterface;
+use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Facades\URL;
 
 /**
@@ -12,10 +13,11 @@ use Illuminate\Support\Facades\URL;
  * another host.
  *
  * Extracted so the sign-in confirmation link and the invitation link are built by
- * the SAME code. The host override is the part worth centralising: it forces the
- * root URL and the scheme for one signing call and restores both in a `finally`,
- * and a second copy of that would be a second chance to forget the restore -- at
- * which point every later URL in the request silently inherits a tenant host.
+ * the SAME code. The host override is the part worth centralizing: it signs on a
+ * generator of its own that carries the tenant origin, so the shared `url` singleton
+ * is never written to. An earlier version forced the origin on the singleton and
+ * "restored" it with `forceRootUrl(null)` -- a reset, not a restore, which wiped
+ * whatever origin or scheme the host itself had forced, for the rest of the process.
  */
 final class SignedTokenUrl
 {
@@ -46,19 +48,43 @@ final class SignedTokenUrl
 
         [$baseUrl, $scheme] = self::absolute($baseUrl);
 
-        // Force the host AND scheme from the base URL for this one signing call,
-        // then restore both so no later URL generation in the request inherits
-        // the tenant host. Forcing the scheme too makes an https base URL sign as
-        // https even when the app itself is served over http.
-        URL::forceRootUrl($baseUrl);
-        URL::forceScheme($scheme);
+        // A generator of its own carries the tenant origin, so the shared `url`
+        // singleton is never touched: nothing to restore, nothing to wipe. The
+        // framework has no getter for a forced origin or scheme, so "put back what
+        // the host had" is not expressible -- not touching it is. The scheme is
+        // still forced on the copy: formatRoot() rewrites the root's scheme through
+        // formatScheme(), so an https tenant on an http app would otherwise sign
+        // as http, and the signature would fail where the link is opened.
+        return self::detached($baseUrl, $scheme)
+            ->temporarySignedRoute($routeName, $expiresAt, ['token' => $plaintext]);
+    }
 
-        try {
-            return self::sign($routeName, $expiresAt, $plaintext);
-        } finally {
-            URL::forceRootUrl(null);
-            URL::forceScheme('');
-        }
+    /**
+     * A generator for one signing call, bound to another origin.
+     *
+     * Constructed rather than cloned: UrlGenerator::withKeyResolver() clones, but a
+     * clone keeps its RouteUrlGenerator pointing at the ORIGINAL instance, so an
+     * origin forced on the clone is ignored by route(). A fresh instance builds its
+     * own RouteUrlGenerator against itself. The key resolver is the one the framework
+     * installs on the live generator, so the signature verifies with the same keys.
+     */
+    private static function detached(string $baseUrl, string $scheme): UrlGenerator
+    {
+        /** @var UrlGenerator $live */
+        $live = URL::getFacadeRoot();
+
+        $generator = new UrlGenerator(app('router')->getRoutes(), $live->getRequest());
+
+        $generator->setKeyResolver(static function (): array {
+            $previous = config('app.previous_keys');
+
+            return [config('app.key'), ...(is_array($previous) ? $previous : [])];
+        });
+        $generator->defaults($live->getDefaultParameters());
+        $generator->useOrigin($baseUrl);
+        $generator->forceScheme($scheme);
+
+        return $generator;
     }
 
     /**
@@ -86,7 +112,7 @@ final class SignedTokenUrl
         }
 
         // `formatScheme()` rather than parsing `url('/')`: it is typed to return a
-        // string, it honours a host that has called `forceScheme()` behind a proxy,
+        // string, it honors a host that has called `forceScheme()` behind a proxy,
         // and in the console it reads the request Laravel builds from `app.url`. It
         // yields the scheme with its separator, e.g. `https://`.
         $scheme = rtrim(URL::formatScheme(), ':/');


### PR DESCRIPTION

### Added

- **`email-magic-link:doctor` reports where the host of an emailed link comes from.** Laravel
  builds every URL from a forced origin when one is set and from the request's `Host` header
  otherwise, and on a server that answers any host a forged header lands in the email. The
  command names which of the three the application is on: a forced origin, hosts restricted by
  the `TrustHosts` middleware, or the request as it came in -- and only the last needs
  attention. The security model page explains the two remedies.

- **Every response on the package's routes carries `X-Robots-Tag: noindex, nofollow`.** The
  bundled layouts have said so in a meta tag all along, but the host's invitation acceptance
  view, a host-supplied invalid view, a custom responder and the countdown script never render
  those layouts. The header covers what the body cannot, and it is attached outside the
  `routes.middleware` key so an override cannot drop it.

- **`MagicLinkRequestRefused` fires when the request endpoint refuses to issue anything:**
  the captcha failed, or the resend guard held the address back (cooldown or rolling cap,
  with the decision that says how long). The consume side always reported its failures
  through `MagicLinkConsumptionFailed`; the request side had no counterpart, so a flood
  against the request form — unknown addresses included — was invisible to a host's
  alerting. The response stays generic. The framework's own `throttle:` limiter answers
  429 before the controller runs and carries no event; the events page says what to
  listen to for that one.

- **`php artisan about` shows an `Email Magic Link` section:** whether the package is
  enabled, the delivery mode, the state of the Fortify bridge and whether invitations are on.
  Registered before the master switch, so a disabled package shows as disabled rather than
  not at all.

### Changed

- **An invalid or expired link rendered as a view now answers with `abort_status` (403 by
  default) instead of 200.** Every other strategy already answered with an error status; the
  `view` strategy alone rendered the refusal as a success, which a link checker, an HTTP cache
  and a crawler all read as one -- on the invitation page, at a URL that carries the token.
  The same key governs both the `abort` and the `view` strategy now.

- **The page title separator is `»` rather than `·`**, so the sign-in tab reads like the rest
  of an application that follows the same convention: `Sign in » Acme`.

- **On the code screen a wrong code is reported on the code field.** The generic failure was
  keyed on `email` for every form, so the code screen marked the (correct, prefilled) email
  address as invalid and left the code boxes untouched; screen readers were told the wrong
  field was wrong. The response stays byte-identical for an unknown address and a wrong code.

- **The purge deletes in chunks (`prune.chunk`, 1000 rows by default), and the command is
  `Isolatable`.** One unbounded `DELETE` over months of rows held every row lock until commit
  and stalled the sign-ins running beside it; `--isolated` now refuses a second copy while
  one runs, for hosts that schedule the command themselves. The self-registered schedule
  entry carries a name and a description, so `schedule:list` reads.

- **The token models hide their hashes when serialized.** `passphrase_hash` is a bcrypt of a
  human-chosen secret, and the models are exposed on public value objects.

- **The package requires `laravel/framework ^13.23`.** The previous floor, `^13.0`, was a
  promise no test could keep: the development toolchain cannot install anything below
  13.23, so versions 13.0 to 13.22 were declared and never exercised. The new floor is the
  lowest version the suite actually runs on.

- **A click on a revoked or superseded invitation is reported as `ClaimFailure::Revoked`, not as
  `AlreadyConsumed`.** The two were folded together, so a host alerting on "somebody used a
  link an administrator withdrew" -- the one refusal that is a signal rather than noise --
  could not tell it from a re-click on an accepted one. The visitor still sees the generic
  refusal. A `match` over `ClaimFailure` without a default arm now has one more case to name.

- **After requesting a code, the address reaches the code screen through the session, not
  the query string.** `/magic-link/code?email=…` put every address into access logs, proxy
  logs, browser history and the `Referer` of every asset the screen loads; the retry path
  already avoided that. The code form no longer reads `?email=` at all, so a crafted link
  cannot prefill a stranger's address either.

### Fixed

- **A table prefix on the database connection broke every claim.** The migrations, the
  models and the query builder all honor a connection's `prefix`, so on a prefixed
  connection the tables were created and written as `app_magic_link_tokens`. The one
  statement that spends a link, a code or an invitation spelled the table name as a
  literal in raw SQL and ran against a table that did not exist: links and codes were sent,
  and every click and every code entry ended in a database error. The table name is now
  built through the connection's grammar, prefix and quoting included.

- **Building a link for another host erased the origin and scheme the application had
  forced.** `issueLink()` and `invite()` accept a `baseUrl` for a tenant domain. To sign
  against it, the generator forced that origin on the application's shared URL generator
  and then "restored" it by forcing null -- which is a reset, not a restore. An application
  that forces `https` behind a TLS-terminating proxy, or pins its origin, lost both the
  moment one tenant link was minted, and every URL generated afterwards in that process
  came out against the raw request: `http://` on an https host, signed URLs that fail on
  arrival, and under a queue worker or Octane for every later request too. Tenant links
  are now signed on a generator of their own, and the shared one is never written to.

- **The sign-in mail was rendered in the queue worker's language, not the requester's.** The
  notification is queued, and a worker renders it later under its own locale unless the
  request's travels with it; nothing set it. Every application that switches the locale per
  request and runs a queue worker sent the magic-link and code mails in the default language
  -- and a synchronous queue, the usual development setup, never showed it. The request's
  locale is now carried on the notification, which is the first place the sender looks.

- **Two pages ahead of a claim still read from the replica.** On a deployment with separate
  read and write connections, the confirm page asks whether a link wants a passphrase and the
  invitation page asks whether the invitation is live -- each in a request of its own, after
  the one that wrote the row. Both lookups went to the read connection, so while the replica
  lagged, a passphrase-gated link rendered without its passphrase field and then failed on
  submit, and a fresh, valid invitation was refused. The earlier fix that pinned the claim
  itself to the primary did not cover these two readers; they are pinned now.

- **A user with two-factor authentication enabled could sign in with a magic link and no
  second factor, on any application where Fortify's `confirm` option is off.** Fortify's
  shipped configuration registers the feature without that option, and then its own verdict
  for "has two-factor enabled" is a stored secret alone; `two_factor_confirmed_at` is never
  written. The handoff re-derived the verdict from that column, so it challenged nobody on
  those applications while Fortify's password login challenged everyone. The handoff now
  asks Fortify's own `hasEnabledTwoFactorAuthentication()`, so the magic link challenges
  exactly the users the password form challenges: with `confirm` on, a secret and a
  confirmation, which still keeps a user mid-setup out of the challenge; with `confirm`
  off, a secret alone.

- **Publishing the migrations and running `migrate` failed on a fresh database.** The
  published copies get a fresh date prefix, so by name they were four other migrations for
  the same tables, and the bundled files were still loaded beside them: the first `CREATE`
  succeeded and the second died with "table already exists", a message that names the table
  and not the cause. Once a published `*_create_magic_link_tokens_table.php` exists the
  package no longer loads its bundled copies. A host that renames the published file says so
  with `EmailMagicLinkServiceProvider::ignoreMigrations()`, which the installer and the
  documentation now name.

- **The WireKit screens had no level-one heading.** The kit's heading component defaults to
  level two, and the three views passed no level, so a person navigating by headings landed
  on nothing at level one -- on the sign-in pages, where nobody knows the layout yet. The
  plain Blade screens always had an `h1`; the WireKit ones now do too.

- **The document's `lang` attribute named the requested locale even when the page spoke the
  fallback language.** On a locale the package has no bundle for, the strings fall back to
  English while `lang` still said, say, `ja`, which sends a screen reader to the wrong voice.
  The attribute now names the language the page actually renders in.

- **A refused sign-in no longer writes the passphrase, or the acceptance form's password
  fields, into the session.** The redirect after a refusal flashes the input so the form can
  re-prefill; it excluded the one-time code and kept everything else, so a wrong passphrase
  and, on the invitation form, `password` and `password_confirmation` landed in the session
  store in the clear. Only the email and the guard are flashed now, as an allowlist.
- **An array where the passphrase should be is treated as no passphrase.** `passphrase[]=a`
  used to be a server error before the claim ran.

- **The plain Blade button was 4.2:1 on the browser's default accent color and the error
  text 2.55:1 in the dark scheme.** The button now paints `CanvasText` on `Canvas` (21:1
  light, 17:1 dark) and the error color switches with the scheme (8.1:1 on the dark canvas).
- **Plain Blade errors are associated with their field.** The field carries `aria-invalid`
  and `aria-describedby` pointing at the message, so a screen reader that lands in the
  autofocused field after a failed submit hears why. The code field also gets a numeric
  keyboard for a digit-only alphabet, and capitals without spell-check for a letter one.
- **The resend hold-back is one message, not two, and the button stays reachable.** The
  request form showed a static "Please wait 30 seconds" beside a timer counting down, and
  the static copy outlived the timer. Only the countdown renders now, inside the form and
  before the button; the button is `aria-disabled` with the countdown as its description
  rather than removed from the tab order, and it is released when the wait ends.

- **The delivery-channel choice survives a failed submit.** A person who picked the one-time
  code, mistyped the address and corrected it received a magic link: the radios never read
  the previous choice back. Both render paths keep it now.
- **The WireKit layout no longer overrides the kit's `color-scheme`.** WireKit declares its
  own since 2.29.0; the layout's `light dark` won and painted native widgets dark on a page
  whose tokens stayed light.

- **`invalid_response.abort_status` is bounded to an error status.** A value outside 400
  to 599 falls back to 403; before, 200 made the refusal a success and 0 or 999 a server
  error the moment it was rendered.
- **`link_ttl` and `code_ttl` follow the same integer rule as `ttl`.** A float was truncated
  by the one and rejected by the other; both now accept an integer or a numeric string and
  nothing else.
- **`fortify.mode` accepts every boolean spelling the other switches accept.** `0`, `off`
  and `no` disable the bridge; they used to leave it in `auto`, the one value the setting was
  written to leave.

- **A link or code whose guard has since been removed from `guards` no longer signs in.** The
  guard was validated only when the token was issued, so an operator closing magic-link
  sign-in on a guard still had every outstanding link honored for its lifetime.

- **The regional bundles answer to the ISO 15897 spelling too.** Laravel's documentation
  prescribes `pt_BR`, `pt_PT`, `en_GB` and `en_US`; the package shipped the hyphenated
  directories only, and an application on the documented spelling silently fell back to
  its fallback locale. Both spellings resolve now.

- **A cache store that cannot hand out the resend lock in time now holds the request back
  instead of answering with a server error.** The guard's lock timeout was never handled, so
  a stalled Redis or a database under contention turned the request endpoint into a 500.

- **The plain Blade passphrase field was unstyled** — the browser default, 153×21 px at
  13 px, beside a 16 px email field, and small enough that iOS zooms on focus. It now
  shares the input rule. On touch pointers the plain screens gain the same 44 px floors
  the WireKit path has (inputs, button, radio rows), the sign-in link on the invalid page
  is a button rather than an 18 px text link, and both layouts size the body with `dvh`
  so iOS Safari centers the card in the visible viewport.

- **`RateLimits::define()` registers the named limiters on the container's `RateLimiter`, not
  on the facade's cached copy.** The documented repair for a per-tenant cache swap --
  `forgetInstance()` then `define()` -- only worked when the host also cleared the facade,
  which nothing said. Without that, the limiters landed on the discarded object while the
  throttle middleware received the new, empty one, and every throttled route answered
  `500 Rate limiter [email-magic-link:request] is not defined.`

- **Every address is normalized the same way, and the normalization strips what `trim()`
  leaves in place.** Lookups, limiter keys and resend keys all lowercased and trimmed by hand
  in five places; they now share one helper built on `Str::trim()`, so a pasted address
  carrying a no-break space, a zero-width space or a byte-order mark keys the same bucket
  as the address typed by hand.

- **A link token that matches nothing costs one statement, not three.** The claim ran its
  atomic `UPDATE` and a third `SELECT` for a hash the first `SELECT` had already proved
  absent -- the path every scanner takes.

- **`InvitationAccepted` implements `ShouldDispatchAfterCommit`.** Its docblock promised
  "after the transaction commits", and the dispatch site kept that promise for the package's
  own transaction only; under a transaction the host opened around the request -- a
  transactional middleware, a test -- listeners ran before the commit. The interface makes the
  promise hold in both cases and costs nothing when no transaction is open.

- **The sign-in mail greets and signs off from the package's own catalog** (`mail_greeting`,
  `mail_salutation`, shipped in every bundled locale). The frame around the body -- `Hello!`,
  `Regards,` -- came from the host's JSON catalog, which most non-English hosts never
  translated, so a German body sat between English lines in a document that declared itself
  German.

### Documentation

- The translations page said WireKit ships only German and used French as its example of a
  locale to copy the English catalog for; WireKit has shipped French, Spanish, Italian, Dutch
  and Portuguese since 2.27.0, and following the page overwrote them with English. The page now
  lists the shipped set and uses a locale neither package ships as its example.
- The response strategies for an invalid link carry their HTTP status in the configuration
  guide, and the security model page explains where the host in an emailed link comes from.

- The Boost skill now covers invitations, the multi-tenancy limiter re-definition and the
  countdown route; the route tables list the countdown script; the contract reference has
  the three invitation contracts and says how the shipped lookup compares addresses; the
  configuration reference has an Invitations section and the deep-merge rule is on the
  configuration guide; the events page's example runs as pasted and warns against logging a
  request URL that is a token; the token-cleanup and multi-tenancy guides say what the
  scheduled purge cannot do under tenancy and how to give it a heartbeat; the WireKit page
  names Livewire's CSP build as the lever; the resend-guard page says the state is a cache
  entry; the landing page states the browser support; CONTRIBUTING names Pest 5, the MySQL
  suite and what CI really runs; and the changelog carries compare links for every version.
